### PR TITLE
Harden external integrations and dependency error mapping

### DIFF
--- a/app/agent/nodes/fetch.py
+++ b/app/agent/nodes/fetch.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 import httpx
 
 from app.agent.state import FetchStudentInput, FetchStudentUpdate
+from app.config import get_settings
 from app.services.siakad_session import (
     cache_student_data,
     get_cached_student_data,
@@ -500,10 +501,13 @@ async def fetch_student_data(state: FetchStudentInput) -> FetchStudentUpdate:
         }
 
     cookies = httpx.Cookies(cookies_dict)
+    settings = get_settings()
 
     try:
         async with httpx.AsyncClient(
-            follow_redirects=True, timeout=30.0, cookies=cookies
+            follow_redirects=True,
+            timeout=settings.siakad_timeout_seconds,
+            cookies=cookies,
         ) as client:
             # Jalankan semua scraper secara concurrent
             # _scrape_nilaimhs di-await terpisah karena GET dulu baru POST
@@ -539,13 +543,42 @@ async def fetch_student_data(state: FetchStudentInput) -> FetchStudentUpdate:
         }
 
     except ConnectionError as e:
-        logger.warning("[fetch] Session expired: %s", e)
+        logger.warning(
+            "Dependency failure dependency=siakad operation=fetch_student_data flow=student mode=auth session_id=%s detail=%s",
+            session_id,
+            e,
+        )
+        return {
+            "student_data": None,
+            "student_fetch_error": True,
+        }
+    except httpx.TimeoutException as e:
+        logger.warning(
+            "Dependency failure dependency=siakad operation=fetch_student_data flow=student mode=timeout session_id=%s detail=%s",
+            session_id,
+            e,
+        )
+        return {
+            "student_data": None,
+            "student_fetch_error": True,
+        }
+    except httpx.TransportError as e:
+        logger.warning(
+            "Dependency failure dependency=siakad operation=fetch_student_data flow=student mode=transport session_id=%s detail=%s",
+            session_id,
+            e,
+        )
         return {
             "student_data": None,
             "student_fetch_error": True,
         }
     except Exception as e:
-        logger.error("[fetch] Error tidak terduga: %s", e)
+        logger.error(
+            "Dependency failure dependency=siakad operation=fetch_student_data flow=student mode=unexpected session_id=%s detail=%s",
+            session_id,
+            e,
+            exc_info=True,
+        )
         return {
             "student_data": None,
             "student_fetch_error": True,

--- a/app/agent/nodes/fetch_nilai_semester.py
+++ b/app/agent/nodes/fetch_nilai_semester.py
@@ -6,6 +6,7 @@ from langchain_core.messages import HumanMessage
 
 from app.agent.nodes.fetch import _scrape_nilaimhs
 from app.agent.state import AgentState
+from app.config import get_settings
 from app.services.llm import get_llm_cheap
 from app.services.siakad_session import get_siakad_cookies
 
@@ -88,15 +89,42 @@ async def fetch_nilai_semester(state: AgentState) -> dict[str, Any]:
             logger.warning("cookies not found")
             return {"nilai_semester_detail": None}
 
-        async with httpx.AsyncClient(cookies=cookies_dict) as client:
+        settings = get_settings()
+        async with httpx.AsyncClient(
+            cookies=cookies_dict,
+            timeout=settings.siakad_timeout_seconds,
+        ) as client:
             result = await _scrape_nilaimhs(client, periode=computed_periode)
             nilai_semester_detail = result["nilai_semester"]
             logger.info(f"Successfully fetched nilai for periode {computed_periode}, total MK: {nilai_semester_detail['total_mata_kuliah']}")
             return {"nilai_semester_detail": nilai_semester_detail}
 
     except ConnectionError as e:
-        logger.warning("[fetch_nilai_semester] Session expired: %s", e)
+        logger.warning(
+            "Dependency failure dependency=siakad operation=fetch_nilai_semester flow=student mode=auth session_id=%s detail=%s",
+            state.get("session_id"),
+            e,
+        )
+        return {"nilai_semester_detail": None}
+    except httpx.TimeoutException as e:
+        logger.warning(
+            "Dependency failure dependency=siakad operation=fetch_nilai_semester flow=student mode=timeout session_id=%s detail=%s",
+            state.get("session_id"),
+            e,
+        )
+        return {"nilai_semester_detail": None}
+    except httpx.TransportError as e:
+        logger.warning(
+            "Dependency failure dependency=siakad operation=fetch_nilai_semester flow=student mode=transport session_id=%s detail=%s",
+            state.get("session_id"),
+            e,
+        )
         return {"nilai_semester_detail": None}
     except Exception as e:
-        logger.error("[fetch_nilai_semester] Unexpected error: %s", e)
+        logger.error(
+            "Dependency failure dependency=siakad operation=fetch_nilai_semester flow=student mode=unexpected session_id=%s detail=%s",
+            state.get("session_id"),
+            e,
+            exc_info=True,
+        )
         return {"nilai_semester_detail": None}

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -14,6 +14,7 @@ from app.schemas import (
     ChatResponse,
     SourceChunk,
 )
+from app.utils.exceptions import AppError
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -71,6 +72,8 @@ async def chat(request: ChatRequest) -> ChatResponse:
     try:
         graph = _get_graph()
         result = await graph.ainvoke(initial_state)
+    except AppError:
+        raise
     except Exception as exc:
         logger.exception("Agent invocation failed: %s", exc)
         raise HTTPException(

--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,18 @@ class Settings(BaseSettings):
     # ── App ─────────────────────────────────────────────
     log_level: str = "INFO"
 
+    # ── Integration hardening ───────────────────────────
+    llm_timeout_seconds: float = 45.0
+    embedding_timeout_seconds: float = 30.0
+    reranker_timeout_seconds: float = 20.0
+    qdrant_timeout_seconds: float = 20.0
+    redis_socket_timeout_seconds: float = 5.0
+    siakad_timeout_seconds: float = 30.0
+
+    # Retries are only used for idempotent remote reads.
+    service_retry_attempts: int = 2
+    service_retry_backoff_seconds: float = 0.3
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/app/services/embeddings.py
+++ b/app/services/embeddings.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import httpx
 
 from app.config import get_settings
+from app.services.resilience import elapsed_ms, now_ms, retry_async
+from app.utils.exceptions import EmbeddingError
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -29,10 +31,47 @@ async def embed_texts(texts: list[str]) -> list[list[float]]:
         "input": texts,
     }
 
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        response = await client.post(url, json=payload, headers=headers)
-        response.raise_for_status()
-        data = response.json()
+    start_ms = now_ms()
+
+    async def _request() -> dict:
+        async with httpx.AsyncClient(timeout=settings.embedding_timeout_seconds) as client:
+            response = await client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            return response.json()
+
+    try:
+        data = await retry_async(
+            operation="embed_texts",
+            dependency="openrouter",
+            fn=_request,
+            retry_on=(httpx.TimeoutException, httpx.TransportError),
+        )
+    except httpx.TimeoutException as exc:
+        logger.error(
+            "Dependency failure dependency=openrouter operation=embed_texts mode=timeout latency_ms=%.1f",
+            elapsed_ms(start_ms),
+        )
+        raise EmbeddingError("Embedding request timed out") from exc
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "Dependency failure dependency=openrouter operation=embed_texts mode=http_status status=%s latency_ms=%.1f",
+            exc.response.status_code,
+            elapsed_ms(start_ms),
+        )
+        raise EmbeddingError("Embedding request failed with upstream HTTP error") from exc
+    except httpx.TransportError as exc:
+        logger.error(
+            "Dependency failure dependency=openrouter operation=embed_texts mode=transport latency_ms=%.1f",
+            elapsed_ms(start_ms),
+        )
+        raise EmbeddingError("Embedding request failed due to network error") from exc
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=openrouter operation=embed_texts mode=unexpected latency_ms=%.1f",
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise EmbeddingError("Embedding request failed unexpectedly") from exc
 
     embeddings: list[list[float]] = [
         item["embedding"] for item in sorted(data["data"], key=lambda x: x["index"])

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -19,6 +19,8 @@ def get_llm(temperature: float = 0.2) -> ChatOpenAI:
         openai_api_base=settings.openrouter_base_url,
         temperature=temperature,
         max_tokens=2048,
+        timeout=settings.llm_timeout_seconds,
+        max_retries=0,
     )
 
 
@@ -31,5 +33,7 @@ def get_llm_cheap(temperature: float = 0.1) -> ChatOpenAI:
         openai_api_base=settings.openrouter_base_url,
         temperature=temperature,
         max_tokens=2048,
+        timeout=settings.llm_timeout_seconds,
+        max_retries=0,
         extra_body={"provider": {"only": ["stepfun/fp8"]}},
     )

--- a/app/services/memory.py
+++ b/app/services/memory.py
@@ -8,6 +8,7 @@ import json
 import redis.asyncio as aioredis
 
 from app.config import get_settings
+from app.utils.exceptions import MemoryStoreError
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -29,6 +30,9 @@ async def get_redis() -> aioredis.Redis:
         _pool = aioredis.from_url(
             settings.redis_url,
             decode_responses=True,
+            socket_timeout=settings.redis_socket_timeout_seconds,
+            socket_connect_timeout=settings.redis_socket_timeout_seconds,
+            retry_on_timeout=False,
         )
     return _pool
 
@@ -38,8 +42,16 @@ async def get_history(session_id: str) -> list[dict[str, str]]:
 
     Returns a list of ``{"role": ..., "content": ...}`` dicts.
     """
-    r = await get_redis()
-    raw = await r.get(_key(session_id))
+    try:
+        r = await get_redis()
+        raw = await r.get(_key(session_id))
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=redis operation=get_history session_id=%s mode=unexpected",
+            session_id,
+            exc_info=True,
+        )
+        raise MemoryStoreError("Failed to load chat history") from exc
     if raw is None:
         return []
     history: list[dict[str, str]] = json.loads(raw)
@@ -54,8 +66,18 @@ async def save_turn(
 ) -> None:
     """Append a user/assistant turn and refresh the TTL."""
     settings = get_settings()
-    r = await get_redis()
-    history = await get_history(session_id)
+    try:
+        r = await get_redis()
+        history = await get_history(session_id)
+    except MemoryStoreError:
+        raise
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=redis operation=save_turn_precheck session_id=%s mode=unexpected",
+            session_id,
+            exc_info=True,
+        )
+        raise MemoryStoreError("Failed to prepare chat history write") from exc
 
     now = datetime.now(UTC).isoformat()
     history.append({"role": "user", "content": user_message, "timestamp": now})
@@ -63,18 +85,34 @@ async def save_turn(
         {"role": "assistant", "content": assistant_message, "timestamp": now}
     )
 
-    await r.set(
-        _key(session_id),
-        json.dumps(history),
-        ex=settings.session_ttl_seconds,
-    )
+    try:
+        await r.set(
+            _key(session_id),
+            json.dumps(history),
+            ex=settings.session_ttl_seconds,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=redis operation=save_turn session_id=%s mode=unexpected",
+            session_id,
+            exc_info=True,
+        )
+        raise MemoryStoreError("Failed to persist chat history") from exc
     logger.debug("Saved turn for session %s (total=%d)", session_id, len(history))
 
 
 async def clear_session(session_id: str) -> None:
     """Delete all history for a session."""
-    r = await get_redis()
-    await r.delete(_key(session_id))
+    try:
+        r = await get_redis()
+        await r.delete(_key(session_id))
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=redis operation=clear_session session_id=%s mode=unexpected",
+            session_id,
+            exc_info=True,
+        )
+        raise MemoryStoreError("Failed to clear chat history") from exc
     logger.info("Cleared session %s", session_id)
 
 

--- a/app/services/reranker.py
+++ b/app/services/reranker.py
@@ -7,6 +7,8 @@ from typing import Any
 import httpx
 
 from app.config import get_settings
+from app.services.resilience import elapsed_ms, now_ms, retry_async
+from app.utils.exceptions import RerankerError
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -44,10 +46,47 @@ async def rerank(
         "top_n": top_n,
     }
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(JINA_RERANK_URL, json=payload, headers=headers)
-        response.raise_for_status()
-        data = response.json()
+    start_ms = now_ms()
+
+    async def _request() -> dict:
+        async with httpx.AsyncClient(timeout=settings.reranker_timeout_seconds) as client:
+            response = await client.post(JINA_RERANK_URL, json=payload, headers=headers)
+            response.raise_for_status()
+            return response.json()
+
+    try:
+        data = await retry_async(
+            operation="rerank",
+            dependency="jina",
+            fn=_request,
+            retry_on=(httpx.TimeoutException, httpx.TransportError),
+        )
+    except httpx.TimeoutException as exc:
+        logger.error(
+            "Dependency failure dependency=jina operation=rerank mode=timeout latency_ms=%.1f",
+            elapsed_ms(start_ms),
+        )
+        raise RerankerError("Reranker request timed out") from exc
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "Dependency failure dependency=jina operation=rerank mode=http_status status=%s latency_ms=%.1f",
+            exc.response.status_code,
+            elapsed_ms(start_ms),
+        )
+        raise RerankerError("Reranker request failed with upstream HTTP error") from exc
+    except httpx.TransportError as exc:
+        logger.error(
+            "Dependency failure dependency=jina operation=rerank mode=transport latency_ms=%.1f",
+            elapsed_ms(start_ms),
+        )
+        raise RerankerError("Reranker request failed due to network error") from exc
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=jina operation=rerank mode=unexpected latency_ms=%.1f",
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise RerankerError("Reranker request failed unexpectedly") from exc
 
     reranked: list[dict[str, Any]] = []
     for item in data.get("results", []):

--- a/app/services/resilience.py
+++ b/app/services/resilience.py
@@ -1,0 +1,55 @@
+"""Shared retry/latency helpers for remote integrations."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import time
+from typing import TypeVar
+
+from app.config import get_settings
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def now_ms() -> float:
+    """Monotonic timestamp in milliseconds."""
+    return time.perf_counter() * 1000
+
+
+def elapsed_ms(start_ms: float) -> float:
+    """Elapsed time in milliseconds since ``start_ms``."""
+    return time.perf_counter() * 1000 - start_ms
+
+
+async def retry_async(
+    operation: str,
+    dependency: str,
+    fn: Callable[[], Awaitable[T]],
+    retry_on: tuple[type[Exception], ...],
+    attempts: int | None = None,
+) -> T:
+    """Retry an idempotent async operation on transient failures."""
+    settings = get_settings()
+    max_attempts = attempts or settings.service_retry_attempts
+    backoff = settings.service_retry_backoff_seconds
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await fn()
+        except retry_on as exc:
+            if attempt >= max_attempts:
+                raise
+            logger.warning(
+                "Transient failure; retrying dependency=%s operation=%s attempt=%d/%d error=%s",
+                dependency,
+                operation,
+                attempt,
+                max_attempts,
+                type(exc).__name__,
+            )
+            await asyncio.sleep(backoff * attempt)
+

--- a/app/services/siakad_session.py
+++ b/app/services/siakad_session.py
@@ -6,7 +6,10 @@ import logging
 from bs4 import BeautifulSoup
 import httpx
 
+from app.config import get_settings
+from app.services.resilience import retry_async
 from app.services.memory import get_redis
+from app.utils.exceptions import MemoryStoreError, SiakadAuthError
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +30,22 @@ HEADERS_BASE = {
 
 async def _login(client: httpx.AsyncClient, email: str, password: str) -> None:
     """Fetch CSRF token lalu POST credentials."""
-    resp = await client.get(LOGIN_URL, headers=HEADERS_BASE)
-    resp.raise_for_status()
+    try:
+        resp = await retry_async(
+            operation="login_page_get",
+            dependency="siakad",
+            fn=lambda: client.get(LOGIN_URL, headers=HEADERS_BASE),
+            retry_on=(httpx.TimeoutException, httpx.TransportError),
+        )
+        resp.raise_for_status()
+    except httpx.TimeoutException as exc:
+        raise SiakadAuthError("SIAKAD login page request timed out") from exc
+    except httpx.HTTPStatusError as exc:
+        raise SiakadAuthError(
+            f"SIAKAD login page returned HTTP {exc.response.status_code}"
+        ) from exc
+    except httpx.TransportError as exc:
+        raise SiakadAuthError("SIAKAD login page request failed due to network error") from exc
 
     soup = BeautifulSoup(resp.text, "html.parser")
     try:
@@ -36,7 +53,7 @@ async def _login(client: httpx.AsyncClient, email: str, password: str) -> None:
         client_id_val = soup.find("input", {"name": "client_id"})["value"]
         redirect_uri_val = soup.find("input", {"name": "redirect_uri"})["value"]
     except (TypeError, KeyError):
-        raise ValueError("Gagal ekstrak CSRF token dari halaman login.")
+        raise SiakadAuthError("Gagal ekstrak CSRF token dari halaman login.")
 
     payload = {
         "email": email,
@@ -47,14 +64,21 @@ async def _login(client: httpx.AsyncClient, email: str, password: str) -> None:
         "redirect_uri": redirect_uri_val,
     }
 
-    resp_post = await client.post(
-        LOGIN_URL,
-        data=payload,
-        headers={**HEADERS_BASE, "Content-Type": "application/x-www-form-urlencoded"},
-    )
+    try:
+        resp_post = await client.post(
+            LOGIN_URL,
+            data=payload,
+            headers={**HEADERS_BASE, "Content-Type": "application/x-www-form-urlencoded"},
+        )
+    except httpx.TimeoutException as exc:
+        raise SiakadAuthError("SIAKAD credential submission timed out") from exc
+    except httpx.TransportError as exc:
+        raise SiakadAuthError(
+            "SIAKAD credential submission failed due to network error"
+        ) from exc
 
     if "Email atau Password salah" in resp_post.text or str(resp_post.url) == LOGIN_URL:
-        raise ValueError("Kredensial tidak valid.")
+        raise SiakadAuthError("Kredensial tidak valid.")
 
 
 async def _activate_siakad(client: httpx.AsyncClient) -> None:
@@ -69,22 +93,35 @@ async def _activate_siakad(client: httpx.AsyncClient) -> None:
         "koderole": "mhs",
         "kodeunit": "55201",
     }
-    resp = await client.post(
-        SIAKAD_LOGIN_URL,
-        data=payload,
-        headers={
-            **HEADERS_BASE,
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Referer": "https://situ2.unpas.ac.id/gate/menu",
-        },
-    )
-    resp.raise_for_status()
+    try:
+        resp = await client.post(
+            SIAKAD_LOGIN_URL,
+            data=payload,
+            headers={
+                **HEADERS_BASE,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": "https://situ2.unpas.ac.id/gate/menu",
+            },
+        )
+        resp.raise_for_status()
+    except httpx.TimeoutException as exc:
+        raise SiakadAuthError("SIAKAD activation timed out") from exc
+    except httpx.HTTPStatusError as exc:
+        raise SiakadAuthError(
+            f"SIAKAD activation returned HTTP {exc.response.status_code}"
+        ) from exc
+    except httpx.TransportError as exc:
+        raise SiakadAuthError("SIAKAD activation failed due to network error") from exc
 
 
 async def init_siakad_session(session_id: str, email: str, password: str) -> bool:
     """Login ke SIAKAD dan simpan cookies ke Redis dengan TTL 1 jam."""
+    settings = get_settings()
     try:
-        async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=settings.siakad_timeout_seconds,
+        ) as client:
             await _login(client, email, password)
             await _activate_siakad(client)
 
@@ -97,11 +134,27 @@ async def init_siakad_session(session_id: str, email: str, password: str) -> boo
             await r.setex(redis_key, 3600, cookie_str)
             logger.info("Session %s berhasil disimpan di Redis.", session_id)
             return True
-    except ValueError as e:
-        logger.warning("Kredensial tidak valid untuk %s: %s", session_id, e)
+    except SiakadAuthError as exc:
+        logger.warning(
+            "Dependency failure dependency=siakad operation=init_session flow=student mode=auth session_id=%s detail=%s",
+            session_id,
+            exc.message,
+        )
         return False
-    except Exception as e:
-        logger.error("Gagal inisiasi SIAKAD session untuk %s: %s", session_id, e)
+    except MemoryStoreError as exc:
+        logger.error(
+            "Dependency failure dependency=redis operation=setex_siakad_session flow=student mode=cache_write session_id=%s detail=%s",
+            session_id,
+            exc.message,
+        )
+        return False
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=siakad operation=init_session flow=student mode=unexpected session_id=%s error=%s",
+            session_id,
+            exc,
+            exc_info=True,
+        )
         return False
 
 
@@ -114,9 +167,11 @@ async def get_siakad_cookies(session_id: str) -> dict | None:
         if cookie_str:
             return json.loads(cookie_str)
         return None
-    except Exception as e:
-        logger.error(
-            "Redis unavailable saat mengambil cookies untuk %s: %s", session_id, e
+    except Exception as exc:
+        logger.warning(
+            "Dependency failure dependency=redis operation=get_siakad_cookies flow=student mode=read session_id=%s error=%s",
+            session_id,
+            exc,
         )
         return None
 

--- a/app/services/vectorstore.py
+++ b/app/services/vectorstore.py
@@ -6,8 +6,11 @@ from typing import Any
 
 from fastembed import SparseTextEmbedding
 from qdrant_client import AsyncQdrantClient, models
+from qdrant_client.http.exceptions import ResponseHandlingException
 
 from app.config import get_settings
+from app.services.resilience import elapsed_ms, now_ms, retry_async
+from app.utils.exceptions import VectorStoreError
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -60,6 +63,7 @@ async def get_qdrant_client() -> AsyncQdrantClient:
         _client = AsyncQdrantClient(
             url=settings.qdrant_url,
             api_key=settings.qdrant_api_key or None,
+            timeout=settings.qdrant_timeout_seconds,
         )
     return _client
 
@@ -72,24 +76,47 @@ async def ensure_collection(vector_size: int) -> None:
     """
     settings = get_settings()
     client = await get_qdrant_client()
-    collections = await client.get_collections()
+    start_ms = now_ms()
+    try:
+        collections = await retry_async(
+            operation="get_collections",
+            dependency="qdrant",
+            fn=client.get_collections,
+            retry_on=(ResponseHandlingException, TimeoutError),
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=get_collections mode=unexpected latency_ms=%.1f",
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to read Qdrant collections") from exc
     names = [c.name for c in collections.collections]
 
     if settings.collection_name not in names:
-        await client.create_collection(
-            collection_name=settings.collection_name,
-            vectors_config={
-                "dense": models.VectorParams(
-                    size=vector_size,
-                    distance=models.Distance.COSINE,
-                ),
-            },
-            sparse_vectors_config={
-                "bm25": models.SparseVectorParams(
-                    modifier=models.Modifier.IDF,
-                ),
-            },
-        )
+        start_ms = now_ms()
+        try:
+            await client.create_collection(
+                collection_name=settings.collection_name,
+                vectors_config={
+                    "dense": models.VectorParams(
+                        size=vector_size,
+                        distance=models.Distance.COSINE,
+                    ),
+                },
+                sparse_vectors_config={
+                    "bm25": models.SparseVectorParams(
+                        modifier=models.Modifier.IDF,
+                    ),
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "Dependency failure dependency=qdrant operation=create_collection mode=unexpected latency_ms=%.1f",
+                elapsed_ms(start_ms),
+                exc_info=True,
+            )
+            raise VectorStoreError("Failed to create Qdrant collection") from exc
         logger.info(
             "Created Qdrant collection '%s' (dense dim=%d + BM25 sparse)",
             settings.collection_name,
@@ -128,10 +155,20 @@ async def upsert_points(
         )
         for uid, vec, sparse, pay in zip(ids, vectors, sparse_vectors, payloads, strict=False)
     ]
-    await client.upsert(
-        collection_name=settings.collection_name,
-        points=points,
-    )
+    start_ms = now_ms()
+    try:
+        await client.upsert(
+            collection_name=settings.collection_name,
+            points=points,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=upsert mode=unexpected points=%d latency_ms=%.1f",
+            len(points),
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to upsert vectors to Qdrant") from exc
     logger.info("Upserted %d points into '%s'", len(points), settings.collection_name)
 
 
@@ -153,24 +190,42 @@ async def hybrid_search(
     # Generate BM25 sparse query vector client-side via fastembed
     sparse_query = _encode_sparse_query(query_text)
 
-    results = await client.query_points(
-        collection_name=settings.collection_name,
-        prefetch=[
-            models.Prefetch(
-                query=sparse_query,
-                using="sparse",
-                limit=prefetch_limit,
-            ),
-            models.Prefetch(
-                query=query_vector,
-                using="dense",
-                limit=prefetch_limit,
-            ),
-        ],
-        query=models.FusionQuery(fusion=models.Fusion.RRF),
-        limit=top_k,
-        with_payload=True,
-    )
+    start_ms = now_ms()
+
+    async def _query():
+        return await client.query_points(
+            collection_name=settings.collection_name,
+            prefetch=[
+                models.Prefetch(
+                    query=sparse_query,
+                    using="sparse",
+                    limit=prefetch_limit,
+                ),
+                models.Prefetch(
+                    query=query_vector,
+                    using="dense",
+                    limit=prefetch_limit,
+                ),
+            ],
+            query=models.FusionQuery(fusion=models.Fusion.RRF),
+            limit=top_k,
+            with_payload=True,
+        )
+
+    try:
+        results = await retry_async(
+            operation="query_points",
+            dependency="qdrant",
+            fn=_query,
+            retry_on=(ResponseHandlingException, TimeoutError),
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=query_points mode=unexpected latency_ms=%.1f",
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to query Qdrant") from exc
 
     docs: list[dict[str, Any]] = []
     for point in results.points:

--- a/app/utils/exceptions.py
+++ b/app/utils/exceptions.py
@@ -55,6 +55,41 @@ class LLMError(AppError):
         super().__init__(message, status_code=502, code="LLM_FAILED")
 
 
+class EmbeddingError(AppError):
+    """Raised when embedding generation fails."""
+
+    def __init__(self, message: str = "Embedding generation failed") -> None:
+        super().__init__(message, status_code=502, code="EMBEDDING_FAILED")
+
+
+class VectorStoreError(AppError):
+    """Raised when Qdrant operations fail."""
+
+    def __init__(self, message: str = "Vector store operation failed") -> None:
+        super().__init__(message, status_code=502, code="VECTORSTORE_FAILED")
+
+
+class MemoryStoreError(AppError):
+    """Raised when Redis memory/session operations fail."""
+
+    def __init__(self, message: str = "Session store operation failed") -> None:
+        super().__init__(message, status_code=503, code="MEMORYSTORE_FAILED")
+
+
+class SiakadAuthError(AppError):
+    """Raised when SIAKAD authentication fails."""
+
+    def __init__(self, message: str = "SIAKAD authentication failed") -> None:
+        super().__init__(message, status_code=401, code="SIAKAD_AUTH_FAILED")
+
+
+class SiakadScrapeError(AppError):
+    """Raised when SIAKAD data scraping fails."""
+
+    def __init__(self, message: str = "SIAKAD scraping failed") -> None:
+        super().__init__(message, status_code=502, code="SIAKAD_SCRAPE_FAILED")
+
+
 # ── FastAPI handlers ────────────────────────────────────
 
 

--- a/tests/test_service_resilience.py
+++ b/tests/test_service_resilience.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.utils.exceptions import EmbeddingError, MemoryStoreError, RerankerError
+
+
+@pytest.mark.asyncio
+async def test_embed_texts_timeout_maps_to_embedding_error():
+    from app.services.embeddings import embed_texts
+
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.TimeoutException("timed out")
+
+    with patch("app.services.embeddings.httpx.AsyncClient") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        with pytest.raises(EmbeddingError, match="timed out"):
+            await embed_texts(["hello"])
+
+
+@pytest.mark.asyncio
+async def test_rerank_http_status_maps_to_reranker_error():
+    from app.services.reranker import rerank
+
+    request = httpx.Request("POST", "https://api.jina.ai/v1/rerank")
+    response = httpx.Response(status_code=503, request=request)
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "upstream error",
+        request=request,
+        response=response,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+
+    with patch("app.services.reranker.httpx.AsyncClient") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+        with pytest.raises(RerankerError, match="HTTP error"):
+            await rerank("query", [{"text": "doc"}], top_n=1)
+
+
+@pytest.mark.asyncio
+async def test_memory_get_history_maps_to_memorystore_error():
+    from app.services.memory import get_history
+
+    with patch("app.services.memory.get_redis", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = RuntimeError("redis down")
+        with pytest.raises(MemoryStoreError, match="load chat history"):
+            await get_history("session-1")
+


### PR DESCRIPTION
## Summary
- add explicit timeout and safe retry controls for external dependencies
- normalize dependency failures into clear internal error categories
- improve flow-aware observability for public vs student integration failures
- add focused resilience tests for timeout/error mapping

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest