### PR TITLE
Add retrieval benchmark and deterministic ingestion controls

### DIFF
--- a/app/eval/__init__.py
+++ b/app/eval/__init__.py
@@ -1,0 +1,2 @@
+"""Retrieval evaluation utilities."""
+

--- a/app/eval/retrieval_eval.py
+++ b/app/eval/retrieval_eval.py
@@ -1,0 +1,337 @@
+"""Retrieval-only benchmark evaluator for the public/admin path."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from app.config import get_settings
+from app.services.embeddings import embed_query
+from app.services.reranker import rerank
+from app.services.vectorstore import hybrid_search
+
+
+@dataclass(frozen=True)
+class TargetSpec:
+    """Expected supporting target for one benchmark query."""
+
+    expected_filename: str | None = None
+    expected_doc_id: str | None = None
+    expected_chunk_index: int | None = None
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """Single retrieval benchmark case."""
+
+    name: str
+    query: str
+    k_target: int
+    targets: tuple[TargetSpec, ...]
+    notes: str | None = None
+
+
+def _parse_target(data: dict[str, Any]) -> TargetSpec:
+    return TargetSpec(
+        expected_filename=data.get("expected_filename"),
+        expected_doc_id=data.get("expected_doc_id"),
+        expected_chunk_index=data.get("expected_chunk_index"),
+    )
+
+
+def load_benchmark_cases(path: str | Path) -> list[BenchmarkCase]:
+    """Load benchmark dataset entries from JSON."""
+    entries = json.loads(Path(path).read_text(encoding="utf-8"))
+    cases: list[BenchmarkCase] = []
+
+    for entry in entries:
+        targets_data = entry.get("expected_targets")
+        if targets_data:
+            targets = tuple(_parse_target(t) for t in targets_data)
+        else:
+            targets = (_parse_target(entry),)
+
+        if not any(t.expected_filename or t.expected_doc_id for t in targets):
+            raise ValueError(
+                f"Case '{entry.get('name', '<unnamed>')}' must include expected_filename or expected_doc_id"
+            )
+
+        cases.append(
+            BenchmarkCase(
+                name=entry["name"],
+                query=entry["query"],
+                k_target=int(entry.get("k_target", 5)),
+                targets=targets,
+                notes=entry.get("notes"),
+            )
+        )
+
+    return cases
+
+
+def load_stage_predictions(path: str | Path) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Load staged candidate lists keyed by benchmark case name."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    pre = payload.get("pre_rerank", {})
+    post = payload.get("post_rerank", {})
+    if not isinstance(pre, dict) or not isinstance(post, dict):
+        raise ValueError("Prediction file must contain pre_rerank and post_rerank maps")
+    return {"pre_rerank": pre, "post_rerank": post}
+
+
+def _matches_target(candidate: dict[str, Any], target: TargetSpec) -> bool:
+    if target.expected_filename is not None:
+        if candidate.get("filename") != target.expected_filename:
+            return False
+    if target.expected_doc_id is not None:
+        if candidate.get("doc_id") != target.expected_doc_id:
+            return False
+    if target.expected_chunk_index is not None:
+        if candidate.get("chunk_index") != target.expected_chunk_index:
+            return False
+    return True
+
+
+def _first_relevant_rank(
+    candidates: list[dict[str, Any]],
+    targets: tuple[TargetSpec, ...],
+) -> int | None:
+    for idx, candidate in enumerate(candidates, start=1):
+        if any(_matches_target(candidate, target) for target in targets):
+            return idx
+    return None
+
+
+def _recall_at_k(
+    candidates: list[dict[str, Any]],
+    targets: tuple[TargetSpec, ...],
+    k: int,
+) -> float:
+    if not targets:
+        return 0.0
+
+    seen: set[int] = set()
+    for candidate in candidates[:k]:
+        for idx, target in enumerate(targets):
+            if idx in seen:
+                continue
+            if _matches_target(candidate, target):
+                seen.add(idx)
+
+    return len(seen) / len(targets)
+
+
+def _round_metrics(metrics: dict[str, float], digits: int = 4) -> dict[str, float]:
+    return {key: round(val, digits) for key, val in metrics.items()}
+
+
+def score_stage(
+    cases: list[BenchmarkCase],
+    stage_results: dict[str, list[dict[str, Any]]],
+    k_eval: int = 5,
+) -> dict[str, Any]:
+    """Compute retrieval metrics for one stage."""
+    if k_eval < 1:
+        raise ValueError("k_eval must be >= 1")
+
+    hits_at_1 = 0
+    hits_at_3 = 0
+    hits_at_5 = 0
+    reciprocal_sum = 0.0
+    recall_at_5_sum = 0.0
+    details: list[dict[str, Any]] = []
+
+    for case in cases:
+        candidates = stage_results.get(case.name, [])[:k_eval]
+        rank = _first_relevant_rank(candidates, case.targets)
+
+        hit1 = 1.0 if rank is not None and rank <= 1 else 0.0
+        hit3 = 1.0 if rank is not None and rank <= 3 else 0.0
+        hit5 = 1.0 if rank is not None and rank <= 5 else 0.0
+        mrr = (1.0 / rank) if rank is not None else 0.0
+        recall5 = _recall_at_k(candidates, case.targets, k=5)
+
+        hits_at_1 += hit1
+        hits_at_3 += hit3
+        hits_at_5 += hit5
+        reciprocal_sum += mrr
+        recall_at_5_sum += recall5
+
+        details.append(
+            {
+                "name": case.name,
+                "k_target": case.k_target,
+                "rank": rank,
+                "hit@1": hit1,
+                "hit@3": hit3,
+                "hit@5": hit5,
+                "mrr": round(mrr, 4),
+                "recall@5": round(recall5, 4),
+            }
+        )
+
+    count = len(cases)
+    metrics = {
+        "hit@1": hits_at_1 / count if count else 0.0,
+        "hit@3": hits_at_3 / count if count else 0.0,
+        "hit@5": hits_at_5 / count if count else 0.0,
+        "mrr": reciprocal_sum / count if count else 0.0,
+        "recall@5": recall_at_5_sum / count if count else 0.0,
+    }
+
+    return {
+        "query_count": count,
+        "k_eval": k_eval,
+        "metrics": _round_metrics(metrics),
+        "per_query": details,
+    }
+
+
+def evaluate_from_predictions(
+    dataset_path: str | Path,
+    predictions_path: str | Path,
+    *,
+    k_eval: int = 5,
+    evaluation_date: str | None = None,
+) -> dict[str, Any]:
+    """Evaluate retrieval stages from prepared candidate lists."""
+    settings = get_settings()
+    cases = load_benchmark_cases(dataset_path)
+    stages = load_stage_predictions(predictions_path)
+
+    stage_scores = {
+        "pre_rerank": score_stage(cases, stages["pre_rerank"], k_eval=k_eval),
+        "post_rerank": score_stage(cases, stages["post_rerank"], k_eval=k_eval),
+    }
+
+    date_value = evaluation_date or datetime.now(UTC).date().isoformat()
+    return {
+        "dataset_id": Path(dataset_path).name,
+        "evaluation_date": date_value,
+        "corpus_id": "fixture-admin-kb-v1",
+        "evaluation_mode": "fixture_predictions",
+        "retrieval_config": {
+            "k_eval": k_eval,
+            "retrieval_top_k": max(k_eval, settings.retrieval_top_k),
+            "rerank_top_n": max(k_eval, settings.rerank_top_n),
+            "relevance_threshold": settings.relevance_threshold,
+        },
+        "dependencies": {
+            "embedding_model": settings.embedding_model,
+            "reranker_model": settings.jina_reranker_model,
+        },
+        "stages": stage_scores,
+    }
+
+
+async def evaluate_live(
+    dataset_path: str | Path,
+    *,
+    k_eval: int = 5,
+    evaluation_date: str | None = None,
+) -> dict[str, Any]:
+    """Run a live retrieval benchmark against configured services."""
+    settings = get_settings()
+    cases = load_benchmark_cases(dataset_path)
+
+    retrieval_top_k = max(k_eval, settings.retrieval_top_k)
+    rerank_top_n = max(k_eval, settings.rerank_top_n)
+
+    pre_results: dict[str, list[dict[str, Any]]] = {}
+    post_results: dict[str, list[dict[str, Any]]] = {}
+
+    for case in cases:
+        vector = await embed_query(case.query)
+        pre_docs = await hybrid_search(
+            query_text=case.query,
+            query_vector=vector,
+            top_k=retrieval_top_k,
+        )
+        reranked_docs = await rerank(
+            query=case.query,
+            documents=pre_docs,
+            top_n=rerank_top_n,
+        )
+        pre_results[case.name] = pre_docs[:k_eval]
+        post_results[case.name] = reranked_docs[:k_eval]
+
+    stage_scores = {
+        "pre_rerank": score_stage(cases, pre_results, k_eval=k_eval),
+        "post_rerank": score_stage(cases, post_results, k_eval=k_eval),
+    }
+
+    date_value = evaluation_date or datetime.now(UTC).date().isoformat()
+    return {
+        "dataset_id": Path(dataset_path).name,
+        "evaluation_date": date_value,
+        "corpus_id": "live-admin-kb",
+        "evaluation_mode": "live_services",
+        "retrieval_config": {
+            "k_eval": k_eval,
+            "retrieval_top_k": retrieval_top_k,
+            "rerank_top_n": rerank_top_n,
+            "relevance_threshold": settings.relevance_threshold,
+        },
+        "dependencies": {
+            "embedding_model": settings.embedding_model,
+            "reranker_model": settings.jina_reranker_model,
+        },
+        "stages": stage_scores,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run retrieval-only benchmark")
+    parser.add_argument("--dataset", required=True, help="Path to benchmark dataset JSON")
+    parser.add_argument("--predictions", help="Path to fixture prediction JSON")
+    parser.add_argument("--output", help="Path to write JSON report")
+    parser.add_argument("--k-eval", type=int, default=5, help="Comparable eval depth")
+    parser.add_argument(
+        "--mode",
+        choices=["fixture", "live"],
+        default="fixture",
+        help="Evaluation mode",
+    )
+    parser.add_argument(
+        "--evaluation-date",
+        default=None,
+        help="Optional YYYY-MM-DD override for deterministic snapshots",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.mode == "live":
+        report = asyncio.run(
+            evaluate_live(
+                dataset_path=args.dataset,
+                k_eval=args.k_eval,
+                evaluation_date=args.evaluation_date,
+            )
+        )
+    else:
+        if not args.predictions:
+            raise SystemExit("--predictions is required in fixture mode")
+        report = evaluate_from_predictions(
+            dataset_path=args.dataset,
+            predictions_path=args.predictions,
+            k_eval=args.k_eval,
+            evaluation_date=args.evaluation_date,
+        )
+
+    rendered = json.dumps(report, indent=2)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/app/ingestion/upserter.py
+++ b/app/ingestion/upserter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from app.ingestion.chunker import Chunk
 from app.services import embeddings as embed_svc
 from app.services import vectorstore as vs
-from app.utils.helpers import generate_point_id
+from app.utils.helpers import generate_chunk_point_id
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -43,6 +43,7 @@ async def upsert_chunks(
         return 0
 
     total = 0
+    collection_prepared = False
 
     for start in range(0, len(chunks), BATCH_SIZE):
         batch = chunks[start : start + BATCH_SIZE]
@@ -54,12 +55,15 @@ async def upsert_chunks(
         # Embed the batch (dense vectors)
         vectors = await embed_svc.embed_texts(enriched_texts)
 
-        # On the very first batch, make sure the collection exists
-        if start == 0:
+        # Ensure the collection exists, then replace any older points
+        # for the same doc_id so re-ingestion stays deterministic.
+        if not collection_prepared:
             await vs.ensure_collection(vector_size=len(vectors[0]))
+            await vs.delete_points_by_doc_id(doc_id)
+            collection_prepared = True
 
         # Build point data — keep original text for display, enriched for BM25
-        ids = [generate_point_id() for _ in batch]
+        ids = [generate_chunk_point_id(doc_id, c.chunk_index) for c in batch]
         payloads = [
             {
                 "text": c.text,

--- a/app/services/vectorstore.py
+++ b/app/services/vectorstore.py
@@ -172,6 +172,39 @@ async def upsert_points(
     logger.info("Upserted %d points into '%s'", len(points), settings.collection_name)
 
 
+async def delete_points_by_doc_id(doc_id: str) -> None:
+    """Delete all points belonging to a single document identity."""
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    selector = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="doc_id",
+                match=models.MatchValue(value=doc_id),
+            )
+        ]
+    )
+
+    start_ms = now_ms()
+    try:
+        await client.delete(
+            collection_name=settings.collection_name,
+            points_selector=selector,
+            wait=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=delete_doc_points mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to delete existing document points") from exc
+
+    logger.info("Deleted previous points for doc_id=%s", doc_id)
+
+
 async def hybrid_search(
     query_text: str,
     query_vector: list[float],

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -7,8 +7,15 @@ import uuid
 
 
 def generate_doc_id(filename: str) -> str:
-    """Deterministic document ID from filename."""
-    return hashlib.sha256(filename.encode()).hexdigest()[:16]
+    """Deterministic document ID from normalized filename."""
+    normalized = filename.strip().lower()
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def generate_chunk_point_id(doc_id: str, chunk_index: int) -> str:
+    """Deterministic chunk point ID from document identity + chunk index."""
+    raw = f"{doc_id}:{chunk_index}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:24]
 
 
 def generate_point_id() -> str:

--- a/docs/retrieval-eval.md
+++ b/docs/retrieval-eval.md
@@ -1,0 +1,60 @@
+## Retrieval Eval (Public/Admin Path)
+
+This benchmark evaluates retrieval quality only for the public/admin knowledge path.
+It does not score final answer generation and does not include student/SIAKAD flows.
+
+### Dataset
+
+- Benchmark dataset: `tests/fixtures/retrieval_eval.json`
+- Fixture predictions: `tests/fixtures/retrieval_eval_predictions.json`
+- Baseline snapshot: `tests/fixtures/retrieval_eval_baseline.json`
+
+Each benchmark case includes:
+- `name`
+- `query`
+- `expected_filename` or `expected_doc_id`
+- `k_target`
+- optional `expected_targets` for multi-target recall checks
+
+### Metrics
+
+The evaluator reports:
+- `Hit@1`
+- `Hit@3`
+- `Hit@5`
+- `MRR`
+- `Recall@5`
+
+Metrics are reported for both stages:
+- `pre_rerank` (raw hybrid retrieval output)
+- `post_rerank` (after reranker)
+
+### Comparable Depth Rule
+
+Both stages are evaluated with the same fixed depth: `k_eval=5`.
+This keeps pre-rerank vs post-rerank comparisons meaningful.
+
+### Run Commands
+
+Fixture-mode (deterministic baseline):
+
+```powershell
+.\.venv\Scripts\python.exe -m app.eval.retrieval_eval `
+  --mode fixture `
+  --dataset tests/fixtures/retrieval_eval.json `
+  --predictions tests/fixtures/retrieval_eval_predictions.json `
+  --output tests/fixtures/retrieval_eval_baseline.json `
+  --k-eval 5 `
+  --evaluation-date 2026-04-08
+```
+
+Live-mode (real services + current corpus):
+
+```powershell
+.\.venv\Scripts\python.exe -m app.eval.retrieval_eval `
+  --mode live `
+  --dataset tests/fixtures/retrieval_eval.json `
+  --output tests/fixtures/retrieval_eval_live.json `
+  --k-eval 5
+```
+

--- a/docs/retrieval-eval.md
+++ b/docs/retrieval-eval.md
@@ -58,3 +58,11 @@ Live-mode (real services + current corpus):
   --k-eval 5
 ```
 
+### Re-ingestion Identity Rules
+
+To keep benchmark comparisons stable:
+- same document identity: normalized filename-derived `doc_id`
+- same chunk identity: deterministic hash of `doc_id + chunk_index`
+- re-ingestion behavior: replace prior chunks for the same `doc_id` before upsert
+
+This prevents silent duplicate accumulation when the same source file is ingested again.

--- a/tests/fixtures/retrieval_eval.json
+++ b/tests/fixtures/retrieval_eval.json
@@ -1,0 +1,131 @@
+[
+  {
+    "name": "q01_admission_requirements",
+    "query": "Apa saja persyaratan pendaftaran mahasiswa baru Teknik Informatika?",
+    "expected_filename": "registrasi_mahasiswa_baru.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q02_admission_schedule",
+    "query": "Kapan jadwal pendaftaran gelombang 2 dibuka?",
+    "expected_filename": "registrasi_mahasiswa_baru.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q03_academic_calendar_start",
+    "query": "Tanggal mulai perkuliahan semester ganjil 2025 kapan?",
+    "expected_filename": "kalender_akademik_2025.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q04_academic_calendar_exam",
+    "query": "Kapan UAS semester ganjil dijadwalkan?",
+    "expected_filename": "kalender_akademik_2025.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q05_krs_deadline",
+    "query": "Batas akhir pengisian KRS online kapan?",
+    "expected_filename": "panduan_krs.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q06_krs_revision",
+    "query": "Bagaimana prosedur revisi KRS setelah submit?",
+    "expected_filename": "panduan_krs.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q07_ukt_payment_channel",
+    "query": "Pembayaran UKT bisa lewat bank apa saja?",
+    "expected_filename": "pembayaran_ukt.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q08_ukt_penalty",
+    "query": "Apakah ada denda jika terlambat bayar UKT?",
+    "expected_filename": "pembayaran_ukt.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q09_leave_requirements",
+    "query": "Syarat pengajuan cuti akademik apa saja?",
+    "expected_filename": "cuti_akademik.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q10_leave_reactivation",
+    "query": "Prosedur aktif kuliah kembali setelah cuti bagaimana?",
+    "expected_filename": "cuti_akademik.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q11_thesis_registration",
+    "query": "Bagaimana alur pendaftaran sidang skripsi?",
+    "expected_filename": "skripsi_dan_sidang.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q12_thesis_examiner",
+    "query": "Penentuan dosen penguji sidang skripsi diatur di mana?",
+    "expected_filename": "skripsi_dan_sidang.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q13_scholarship_types",
+    "query": "Jenis beasiswa internal kampus yang tersedia apa saja?",
+    "expected_filename": "beasiswa_unpas.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q14_scholarship_documents",
+    "query": "Dokumen wajib untuk pengajuan beasiswa apa?",
+    "expected_filename": "beasiswa_unpas.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q15_transfer_policy",
+    "query": "Syarat perpindahan program studi di fakultas teknik apa?",
+    "expected_filename": "perpindahan_prodi.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q16_transfer_timeline",
+    "query": "Kapan periode pengajuan perpindahan prodi dibuka?",
+    "expected_filename": "perpindahan_prodi.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q17_graduation_requirements",
+    "query": "Syarat ikut yudisium dan wisuda apa saja?",
+    "expected_filename": "wisuda_dan_yudisium.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q18_graduation_registration",
+    "query": "Alur pendaftaran wisuda dilakukan lewat sistem apa?",
+    "expected_filename": "wisuda_dan_yudisium.pdf",
+    "k_target": 5
+  },
+  {
+    "name": "q19_online_service_helpdesk",
+    "query": "Jika layanan administrasi online bermasalah, hubungi ke mana?",
+    "expected_filename": "layanan_administrasi_online.pdf",
+    "k_target": 3
+  },
+  {
+    "name": "q20_payment_or_helpdesk",
+    "query": "Informasi pembayaran UKT dan kontak layanan online ada di dokumen mana?",
+    "k_target": 5,
+    "expected_targets": [
+      {
+        "expected_filename": "pembayaran_ukt.pdf"
+      },
+      {
+        "expected_filename": "layanan_administrasi_online.pdf"
+      }
+    ],
+    "notes": "Multi-target query for recall sanity check."
+  }
+]
+

--- a/tests/fixtures/retrieval_eval_baseline.json
+++ b/tests/fixtures/retrieval_eval_baseline.json
@@ -1,0 +1,444 @@
+{
+  "dataset_id": "retrieval_eval.json",
+  "evaluation_date": "2026-04-08",
+  "corpus_id": "fixture-admin-kb-v1",
+  "evaluation_mode": "fixture_predictions",
+  "retrieval_config": {
+    "k_eval": 5,
+    "retrieval_top_k": 10,
+    "rerank_top_n": 5,
+    "relevance_threshold": 0.17
+  },
+  "dependencies": {
+    "embedding_model": "qwen/qwen3-embedding-8b",
+    "reranker_model": "jina-reranker-v3"
+  },
+  "stages": {
+    "pre_rerank": {
+      "query_count": 20,
+      "k_eval": 5,
+      "metrics": {
+        "hit@1": 0.5,
+        "hit@3": 0.85,
+        "hit@5": 0.95,
+        "mrr": 0.6833,
+        "recall@5": 0.95
+      },
+      "per_query": [
+        {
+          "name": "q01_admission_requirements",
+          "k_target": 3,
+          "rank": 3,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.3333,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q02_admission_schedule",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q03_academic_calendar_start",
+          "k_target": 3,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q04_academic_calendar_exam",
+          "k_target": 5,
+          "rank": 4,
+          "hit@1": 0.0,
+          "hit@3": 0.0,
+          "hit@5": 1.0,
+          "mrr": 0.25,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q05_krs_deadline",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q06_krs_revision",
+          "k_target": 5,
+          "rank": 3,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.3333,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q07_ukt_payment_channel",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q08_ukt_penalty",
+          "k_target": 5,
+          "rank": 4,
+          "hit@1": 0.0,
+          "hit@3": 0.0,
+          "hit@5": 1.0,
+          "mrr": 0.25,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q09_leave_requirements",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q10_leave_reactivation",
+          "k_target": 5,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q11_thesis_registration",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q12_thesis_examiner",
+          "k_target": 5,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q13_scholarship_types",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q14_scholarship_documents",
+          "k_target": 5,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q15_transfer_policy",
+          "k_target": 5,
+          "rank": null,
+          "hit@1": 0.0,
+          "hit@3": 0.0,
+          "hit@5": 0.0,
+          "mrr": 0.0,
+          "recall@5": 0.0
+        },
+        {
+          "name": "q16_transfer_timeline",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q17_graduation_requirements",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q18_graduation_registration",
+          "k_target": 5,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q19_online_service_helpdesk",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q20_payment_or_helpdesk",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        }
+      ]
+    },
+    "post_rerank": {
+      "query_count": 20,
+      "k_eval": 5,
+      "metrics": {
+        "hit@1": 0.85,
+        "hit@3": 1.0,
+        "hit@5": 1.0,
+        "mrr": 0.9167,
+        "recall@5": 1.0
+      },
+      "per_query": [
+        {
+          "name": "q01_admission_requirements",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q02_admission_schedule",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q03_academic_calendar_start",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q04_academic_calendar_exam",
+          "k_target": 5,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q05_krs_deadline",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q06_krs_revision",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q07_ukt_payment_channel",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q08_ukt_penalty",
+          "k_target": 5,
+          "rank": 2,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.5,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q09_leave_requirements",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q10_leave_reactivation",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q11_thesis_registration",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q12_thesis_examiner",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q13_scholarship_types",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q14_scholarship_documents",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q15_transfer_policy",
+          "k_target": 5,
+          "rank": 3,
+          "hit@1": 0.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 0.3333,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q16_transfer_timeline",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q17_graduation_requirements",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q18_graduation_registration",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q19_online_service_helpdesk",
+          "k_target": 3,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        },
+        {
+          "name": "q20_payment_or_helpdesk",
+          "k_target": 5,
+          "rank": 1,
+          "hit@1": 1.0,
+          "hit@3": 1.0,
+          "hit@5": 1.0,
+          "mrr": 1.0,
+          "recall@5": 1.0
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/retrieval_eval_predictions.json
+++ b/tests/fixtures/retrieval_eval_predictions.json
@@ -1,0 +1,287 @@
+{
+  "pre_rerank": {
+    "q01_admission_requirements": [
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q02_admission_schedule": [
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "pembayaran_ukt.pdf"}
+    ],
+    "q03_academic_calendar_start": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "cuti_akademik.pdf"}
+    ],
+    "q04_academic_calendar_exam": [
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"}
+    ],
+    "q05_krs_deadline": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "cuti_akademik.pdf"}
+    ],
+    "q06_krs_revision": [
+      {"filename": "cuti_akademik.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q07_ukt_payment_channel": [
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"}
+    ],
+    "q08_ukt_penalty": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "cuti_akademik.pdf"}
+    ],
+    "q09_leave_requirements": [
+      {"filename": "cuti_akademik.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q10_leave_reactivation": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "cuti_akademik.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q11_thesis_registration": [
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q12_thesis_examiner": [
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "beasiswa_unpas.pdf"}
+    ],
+    "q13_scholarship_types": [
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q14_scholarship_documents": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"}
+    ],
+    "q15_transfer_policy": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q16_transfer_timeline": [
+      {"filename": "perpindahan_prodi.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q17_graduation_requirements": [
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "pembayaran_ukt.pdf"}
+    ],
+    "q18_graduation_registration": [
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"}
+    ],
+    "q19_online_service_helpdesk": [
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"}
+    ],
+    "q20_payment_or_helpdesk": [
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ]
+  },
+  "post_rerank": {
+    "q01_admission_requirements": [
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q02_admission_schedule": [
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "pembayaran_ukt.pdf"}
+    ],
+    "q03_academic_calendar_start": [
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "cuti_akademik.pdf"}
+    ],
+    "q04_academic_calendar_exam": [
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q05_krs_deadline": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "cuti_akademik.pdf"}
+    ],
+    "q06_krs_revision": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "cuti_akademik.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q07_ukt_payment_channel": [
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"}
+    ],
+    "q08_ukt_penalty": [
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "cuti_akademik.pdf"}
+    ],
+    "q09_leave_requirements": [
+      {"filename": "cuti_akademik.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q10_leave_reactivation": [
+      {"filename": "cuti_akademik.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q11_thesis_registration": [
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q12_thesis_examiner": [
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "beasiswa_unpas.pdf"}
+    ],
+    "q13_scholarship_types": [
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q14_scholarship_documents": [
+      {"filename": "beasiswa_unpas.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"}
+    ],
+    "q15_transfer_policy": [
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "perpindahan_prodi.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"}
+    ],
+    "q16_transfer_timeline": [
+      {"filename": "perpindahan_prodi.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"}
+    ],
+    "q17_graduation_requirements": [
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "pembayaran_ukt.pdf"}
+    ],
+    "q18_graduation_registration": [
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"}
+    ],
+    "q19_online_service_helpdesk": [
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "wisuda_dan_yudisium.pdf"},
+      {"filename": "panduan_krs.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"}
+    ],
+    "q20_payment_or_helpdesk": [
+      {"filename": "pembayaran_ukt.pdf"},
+      {"filename": "layanan_administrasi_online.pdf"},
+      {"filename": "registrasi_mahasiswa_baru.pdf"},
+      {"filename": "kalender_akademik_2025.pdf"},
+      {"filename": "skripsi_dan_sidang.pdf"}
+    ]
+  }
+}
+

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.ingestion.chunker import Chunk
+from app.utils.helpers import generate_chunk_point_id
 
 
 @pytest.mark.asyncio
@@ -36,13 +37,21 @@ async def test_upsert_chunks_batch():
             return_value=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
         )
         mock_vs.ensure_collection = AsyncMock()
+        mock_vs.delete_points_by_doc_id = AsyncMock()
         mock_vs.upsert_points = AsyncMock()
 
         result = await upsert_chunks(chunks, doc_id="abc", filename="doc.pdf")
 
     assert result == 2
     mock_embed.embed_texts.assert_called_once()
+    mock_vs.delete_points_by_doc_id.assert_called_once_with("abc")
     mock_vs.upsert_points.assert_called_once()
+
+    call_kwargs = mock_vs.upsert_points.call_args.kwargs
+    assert call_kwargs["ids"] == [
+        generate_chunk_point_id("abc", 0),
+        generate_chunk_point_id("abc", 1),
+    ]
 
 
 def test_chunk_dataclass():
@@ -58,6 +67,12 @@ def test_chunk_page_defaults_to_none():
     """Chunk.page defaults to None when not provided."""
     chunk = Chunk(text="no page", headings=[], chunk_index=0)
     assert chunk.page is None
+
+
+def test_generate_doc_id_is_case_insensitive():
+    from app.utils.helpers import generate_doc_id
+
+    assert generate_doc_id("Admin_Guide.PDF") == generate_doc_id("admin_guide.pdf")
 
 
 @pytest.mark.asyncio
@@ -91,3 +106,35 @@ async def test_pipeline_ingest():
     mock_parse.assert_called_once()
     mock_chunk.assert_called_once_with(mock_doc)
     mock_upsert.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_chunks_reingestion_replaces_same_doc_points():
+    """Repeated ingestion should replace prior document points deterministically."""
+    from app.ingestion.upserter import upsert_chunks
+
+    chunks = [
+        Chunk(text="Chunk 1", headings=["A"], chunk_index=0, page=1),
+        Chunk(text="Chunk 2", headings=["B"], chunk_index=1, page=1),
+    ]
+
+    with (
+        patch("app.ingestion.upserter.embed_svc") as mock_embed,
+        patch("app.ingestion.upserter.vs") as mock_vs,
+    ):
+        mock_embed.embed_texts = AsyncMock(
+            return_value=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        )
+        mock_vs.ensure_collection = AsyncMock()
+        mock_vs.delete_points_by_doc_id = AsyncMock()
+        mock_vs.upsert_points = AsyncMock()
+
+        await upsert_chunks(chunks, doc_id="doc-fixed", filename="admin.pdf")
+        await upsert_chunks(chunks, doc_id="doc-fixed", filename="admin.pdf")
+
+    # Explicit replacement should run each ingestion call.
+    assert mock_vs.delete_points_by_doc_id.call_count == 2
+
+    first_ids = mock_vs.upsert_points.call_args_list[0].kwargs["ids"]
+    second_ids = mock_vs.upsert_points.call_args_list[1].kwargs["ids"]
+    assert first_ids == second_ids

--- a/tests/test_retrieval_eval.py
+++ b/tests/test_retrieval_eval.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.eval.retrieval_eval import evaluate_from_predictions, load_benchmark_cases
+
+
+FIXTURES_DIR = Path("tests/fixtures")
+DATASET_PATH = FIXTURES_DIR / "retrieval_eval.json"
+PREDICTIONS_PATH = FIXTURES_DIR / "retrieval_eval_predictions.json"
+BASELINE_PATH = FIXTURES_DIR / "retrieval_eval_baseline.json"
+
+
+def test_retrieval_eval_dataset_is_loadable():
+    cases = load_benchmark_cases(DATASET_PATH)
+    assert len(cases) >= 20
+    assert all(case.query for case in cases)
+
+
+def test_retrieval_eval_metrics_match_baseline_snapshot():
+    report = evaluate_from_predictions(
+        dataset_path=DATASET_PATH,
+        predictions_path=PREDICTIONS_PATH,
+        k_eval=5,
+        evaluation_date="2026-04-08",
+    )
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+    assert report["dataset_id"] == baseline["dataset_id"]
+    assert report["evaluation_date"] == baseline["evaluation_date"]
+    assert report["retrieval_config"] == baseline["retrieval_config"]
+    assert report["dependencies"] == baseline["dependencies"]
+    assert report["stages"]["pre_rerank"]["metrics"] == baseline["stages"]["pre_rerank"]["metrics"]
+    assert report["stages"]["post_rerank"]["metrics"] == baseline["stages"]["post_rerank"]["metrics"]
+
+
+def test_retrieval_eval_uses_comparable_depth():
+    report = evaluate_from_predictions(
+        dataset_path=DATASET_PATH,
+        predictions_path=PREDICTIONS_PATH,
+        k_eval=5,
+        evaluation_date="2026-04-08",
+    )
+
+    pre = report["stages"]["pre_rerank"]
+    post = report["stages"]["post_rerank"]
+
+    assert pre["k_eval"] == 5
+    assert post["k_eval"] == 5
+    assert pre["query_count"] == post["query_count"]
+


### PR DESCRIPTION
## Summary\n- add retrieval-only benchmark dataset, evaluator, and baseline snapshot for the public/admin path\n- report comparable-depth metrics for pre-rerank and post-rerank stages (Hit@1/3/5, MRR, Recall@5)\n- document benchmark run workflow and interpretation\n- make ingestion identities deterministic and replace existing doc points on re-ingest to prevent silent duplicate accumulation\n\n## Commit split\n- 343a443 PR1 scope: retrieval benchmark + evaluator + baseline\n- 8ac0388 PR2 scope: ingestion identity + dedup/replacement behavior\n\n## Testing\n- .\\.venv\\Scripts\\python.exe -m pytest (97 passed)