### PR TITLE
Tighten security across public and student flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,15 @@ HYBRID_PREFETCH_LIMIT=20
 
 # ── App ─────────────────────────────────────────────────
 LOG_LEVEL=INFO
+APP_ENV=development
+# Comma-separated allowed origins. In local dev, leave empty to use localhost defaults.
+CORS_ALLOW_ORIGINS=
+
+# In non-local environments, /ingest requires this header token (X-Ingest-Token).
+INGEST_API_KEY=
+
+# ── Route abuse protection ──────────────────────────────
+RATE_LIMIT_WINDOW_SECONDS=60
+AUTH_LOGIN_RATE_LIMIT=8
+CHAT_RATE_LIMIT=40
+INGEST_RATE_LIMIT=6

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -3,10 +3,13 @@
 import logging
 import uuid
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
-from app.services.siakad_session import init_siakad_session
+from app.config import get_settings
+from app.services.rate_limiter import allow_request
+from app.services.siakad_session import init_siakad_session, issue_student_access_token
+from app.utils.security import mask_email, mask_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -20,21 +23,32 @@ class LoginRequest(BaseModel):
 
 class LoginResponse(BaseModel):
     session_id: str
+    student_access_token: str
     status: str
     message: str
 
 
 @router.post("/login", response_model=LoginResponse)
-async def login_siakad(request: LoginRequest):
+async def login_siakad(request: LoginRequest, http_request: Request):
     """
     Login ke SIAKAD dan simpan cookies ke Redis.
     Email dan password hanya diproses in-memory dan tidak disimpan.
     """
+    settings = get_settings()
+    client_ip = http_request.client.host if http_request.client else "unknown"
+    limit_key = f"auth_login:{client_ip}"
+    if not allow_request(
+        key=limit_key,
+        limit=settings.auth_login_rate_limit,
+        window_seconds=settings.rate_limit_window_seconds,
+    ):
+        raise HTTPException(status_code=429, detail="Too many login attempts.")
+
     session_id = str(uuid.uuid4())
     logger.info(
-        "Menerima request login SIAKAD untuk session_id=%s, email=%s",
-        session_id,
-        request.email,
+        "Menerima request login SIAKAD untuk session=%s, email=%s",
+        mask_session_id(session_id),
+        mask_email(str(request.email)),
     )
 
     success = await init_siakad_session(
@@ -43,18 +57,22 @@ async def login_siakad(request: LoginRequest):
 
     if not success:
         logger.warning(
-            "SIAKAD login gagal untuk session_id=%s, email=%s",
-            session_id,
-            request.email,
+            "SIAKAD login gagal untuk session=%s, email=%s",
+            mask_session_id(session_id),
+            mask_email(str(request.email)),
         )
         raise HTTPException(
             status_code=401,
             detail="Login SIAKAD gagal. Periksa kembali email dan password Anda.",
         )
 
+    student_access_token = await issue_student_access_token(session_id)
     logger.info(
-        "[login] Authenticated session created: %s untuk %s", session_id, request.email
+        "[login] Authenticated session created: %s", mask_session_id(session_id)
     )
     return LoginResponse(
-        session_id=session_id, status="authenticated", message="Login SIAKAD berhasil"
+        session_id=session_id,
+        student_access_token=student_access_token,
+        status="authenticated",
+        message="Login SIAKAD berhasil",
     )

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from functools import lru_cache
 import uuid
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Request
 
+from app.config import get_settings
+from app.services.rate_limiter import allow_request
+from app.services.siakad_session import (
+    has_student_access_binding,
+    verify_student_access_token,
+)
 from app.schemas import (
     ChatHistoryItem,
     ChatHistoryResponse,
@@ -16,6 +22,7 @@ from app.schemas import (
 )
 from app.utils.exceptions import AppError
 from app.utils.logger import get_logger
+from app.utils.security import mask_session_id
 
 logger = get_logger(__name__)
 
@@ -45,15 +52,41 @@ def _get_graph():
 
 
 @router.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest) -> ChatResponse:
+async def chat(
+    request: ChatRequest,
+    http_request: Request,
+    x_student_access_token: str | None = Header(
+        default=None,
+        alias="X-Student-Access-Token",
+    ),
+) -> ChatResponse:
     """Process a chat message through the LangGraph agent."""
+    settings = get_settings()
+    client_ip = http_request.client.host if http_request.client else "unknown"
+    if not allow_request(
+        key=f"chat:{client_ip}",
+        limit=settings.chat_rate_limit,
+        window_seconds=settings.rate_limit_window_seconds,
+    ):
+        raise HTTPException(status_code=429, detail="Too many chat requests.")
+
     session_id, is_authenticated = resolve_session_id(request.session_id)
+    session_hint = mask_session_id(session_id)
+
+    if is_authenticated and await has_student_access_binding(session_id):
+        valid = await verify_student_access_token(session_id, x_student_access_token)
+        if not valid:
+            logger.warning("Student token verification failed for session=%s", session_hint)
+            raise HTTPException(
+                status_code=401,
+                detail="Student access token is required for this session.",
+            )
 
     logger.info(
-        "Chat request: session=%s, auth=%s, message=%s",
-        session_id,
+        "Chat request: session=%s, auth=%s, message_length=%d",
+        session_hint,
         is_authenticated,
-        request.message[:80],
+        len(request.message),
     )
 
     initial_state = {
@@ -93,9 +126,23 @@ async def chat(request: ChatRequest) -> ChatResponse:
 
 
 @router.get("/chat/{session_id}/history", response_model=ChatHistoryResponse)
-async def get_chat_history(session_id: str) -> ChatHistoryResponse:
+async def get_chat_history(
+    session_id: str,
+    x_student_access_token: str | None = Header(
+        default=None,
+        alias="X-Student-Access-Token",
+    ),
+) -> ChatHistoryResponse:
     """Retrieve chat history for a session from Redis."""
     from app.services.memory import get_history
+
+    if await has_student_access_binding(session_id):
+        valid = await verify_student_access_token(session_id, x_student_access_token)
+        if not valid:
+            raise HTTPException(
+                status_code=401,
+                detail="Student access token is required for this session.",
+            )
 
     history = await get_history(session_id)
 

--- a/app/api/ingest.py
+++ b/app/api/ingest.py
@@ -6,11 +6,14 @@ from pathlib import Path
 import shutil
 import tempfile
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request, UploadFile
 
+from app.config import get_settings
 from app.ingestion.pipeline import ingest_document
+from app.services.rate_limiter import allow_request
 from app.schemas import IngestResponse
 from app.utils.logger import get_logger
+from app.utils.security import is_local_env
 
 logger = get_logger(__name__)
 
@@ -36,12 +39,34 @@ def _validate_file(file: UploadFile) -> None:
 async def ingest(
     file: UploadFile,
     background_tasks: BackgroundTasks,
+    request: Request,
+    x_ingest_token: str | None = Header(default=None, alias="X-Ingest-Token"),
 ) -> IngestResponse:
     """Upload a document and kick off ingestion.
 
     The file is saved to a temp directory, then the ingestion pipeline
     runs as a **background task** so the response returns quickly.
     """
+    settings = get_settings()
+    app_env = settings.app_env
+
+    if settings.ingest_api_key:
+        if x_ingest_token != settings.ingest_api_key:
+            raise HTTPException(status_code=403, detail="Invalid ingest token.")
+    elif not is_local_env(app_env):
+        raise HTTPException(
+            status_code=503,
+            detail="Ingest route is disabled until INGEST_API_KEY is configured.",
+        )
+
+    client_ip = request.client.host if request.client else "unknown"
+    if not allow_request(
+        key=f"ingest:{client_ip}",
+        limit=settings.ingest_rate_limit,
+        window_seconds=settings.rate_limit_window_seconds,
+    ):
+        raise HTTPException(status_code=429, detail="Too many ingest requests.")
+
     _validate_file(file)
     assert file.filename is not None  # guarded by _validate_file
 

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -46,6 +47,15 @@ class Settings(BaseSettings):
 
     # ── App ─────────────────────────────────────────────
     log_level: str = "INFO"
+    app_env: str = "development"
+    cors_allow_origins: str = ""
+    ingest_api_key: str | None = None
+
+    # ── Route abuse protection ──────────────────────────
+    rate_limit_window_seconds: int = 60
+    auth_login_rate_limit: int = 8
+    chat_rate_limit: int = 40
+    ingest_rate_limit: int = 6
 
     # ── Integration hardening ───────────────────────────
     llm_timeout_seconds: float = 45.0
@@ -58,6 +68,11 @@ class Settings(BaseSettings):
     # Retries are only used for idempotent remote reads.
     service_retry_attempts: int = 2
     service_retry_backoff_seconds: float = 0.3
+
+    @field_validator("app_env")
+    @classmethod
+    def normalize_app_env(cls, value: str) -> str:
+        return value.strip().lower()
 
 
 @lru_cache

--- a/app/main.py
+++ b/app/main.py
@@ -12,8 +12,10 @@ from app.api.auth import router as auth_router
 from app.api.chat import router as chat_router
 from app.api.health import router as health_router
 from app.api.ingest import router as ingest_router
+from app.config import get_settings
 from app.utils.exceptions import register_exception_handlers
 from app.utils.logger import get_logger, setup_logging
+from app.utils.security import is_local_env, parse_cors_origins
 
 
 @asynccontextmanager
@@ -44,9 +46,21 @@ app = FastAPI(
 
 # ── Middleware ───────────────────────────────────────────
 
+settings = get_settings()
+cors_origins = parse_cors_origins(settings.cors_allow_origins)
+
+if not cors_origins and is_local_env(settings.app_env):
+    cors_origins = [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    ]
+
+if "*" in cors_origins and not is_local_env(settings.app_env):
+    raise RuntimeError("Wildcard CORS is not allowed outside local development.")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/services/memory.py
+++ b/app/services/memory.py
@@ -10,6 +10,7 @@ import redis.asyncio as aioredis
 from app.config import get_settings
 from app.utils.exceptions import MemoryStoreError
 from app.utils.logger import get_logger
+from app.utils.security import mask_session_id
 
 logger = get_logger(__name__)
 
@@ -48,14 +49,18 @@ async def get_history(session_id: str) -> list[dict[str, str]]:
     except Exception as exc:
         logger.error(
             "Dependency failure dependency=redis operation=get_history session_id=%s mode=unexpected",
-            session_id,
+            mask_session_id(session_id),
             exc_info=True,
         )
         raise MemoryStoreError("Failed to load chat history") from exc
     if raw is None:
         return []
     history: list[dict[str, str]] = json.loads(raw)
-    logger.debug("Loaded %d turns for session %s", len(history), session_id)
+    logger.debug(
+        "Loaded %d turns for session %s",
+        len(history),
+        mask_session_id(session_id),
+    )
     return history
 
 
@@ -74,7 +79,7 @@ async def save_turn(
     except Exception as exc:
         logger.error(
             "Dependency failure dependency=redis operation=save_turn_precheck session_id=%s mode=unexpected",
-            session_id,
+            mask_session_id(session_id),
             exc_info=True,
         )
         raise MemoryStoreError("Failed to prepare chat history write") from exc
@@ -94,11 +99,15 @@ async def save_turn(
     except Exception as exc:
         logger.error(
             "Dependency failure dependency=redis operation=save_turn session_id=%s mode=unexpected",
-            session_id,
+            mask_session_id(session_id),
             exc_info=True,
         )
         raise MemoryStoreError("Failed to persist chat history") from exc
-    logger.debug("Saved turn for session %s (total=%d)", session_id, len(history))
+    logger.debug(
+        "Saved turn for session %s (total=%d)",
+        mask_session_id(session_id),
+        len(history),
+    )
 
 
 async def clear_session(session_id: str) -> None:
@@ -109,11 +118,11 @@ async def clear_session(session_id: str) -> None:
     except Exception as exc:
         logger.error(
             "Dependency failure dependency=redis operation=clear_session session_id=%s mode=unexpected",
-            session_id,
+            mask_session_id(session_id),
             exc_info=True,
         )
         raise MemoryStoreError("Failed to clear chat history") from exc
-    logger.info("Cleared session %s", session_id)
+    logger.info("Cleared session %s", mask_session_id(session_id))
 
 
 async def close_redis() -> None:

--- a/app/services/rate_limiter.py
+++ b/app/services/rate_limiter.py
@@ -1,0 +1,49 @@
+"""Simple in-process sliding-window rate limiter."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+import time
+from typing import DefaultDict
+
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class InMemoryRateLimiter:
+    """Per-process sliding-window limiter keyed by route/client fingerprint."""
+
+    def __init__(self) -> None:
+        self._buckets: DefaultDict[str, deque[float]] = defaultdict(deque)
+
+    def allow(self, key: str, limit: int, window_seconds: int) -> bool:
+        now = time.monotonic()
+        cutoff = now - window_seconds
+        bucket = self._buckets[key]
+
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+
+        if len(bucket) >= limit:
+            return False
+
+        bucket.append(now)
+        return True
+
+    def reset(self) -> None:
+        self._buckets.clear()
+
+
+_limiter = InMemoryRateLimiter()
+
+
+def allow_request(key: str, limit: int, window_seconds: int) -> bool:
+    """Shared helper used by API routes."""
+    return _limiter.allow(key=key, limit=limit, window_seconds=window_seconds)
+
+
+def reset_rate_limiter() -> None:
+    """Test helper for deterministic rate-limit tests."""
+    _limiter.reset()
+

--- a/app/services/siakad_session.py
+++ b/app/services/siakad_session.py
@@ -1,7 +1,10 @@
 """SIAKAD Session Management with Redis."""
 
+import hashlib
+import hmac
 import json
 import logging
+import secrets
 
 from bs4 import BeautifulSoup
 import httpx
@@ -10,6 +13,7 @@ from app.config import get_settings
 from app.services.resilience import retry_async
 from app.services.memory import get_redis
 from app.utils.exceptions import MemoryStoreError, SiakadAuthError
+from app.utils.security import mask_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +30,16 @@ HEADERS_BASE = {
         "Chrome/120.0.0.0 Safari/537.36"
     )
 }
+
+AUTH_TTL_SECONDS = 3600
+
+
+def _auth_key(session_id: str) -> str:
+    return f"siakad_auth:{session_id}"
+
+
+def _hash_access_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
 
 
 async def _login(client: httpx.AsyncClient, email: str, password: str) -> None:
@@ -131,30 +145,69 @@ async def init_siakad_session(session_id: str, email: str, password: str) -> boo
 
             r = await get_redis()
             redis_key = f"siakad_session:{session_id}"
-            await r.setex(redis_key, 3600, cookie_str)
-            logger.info("Session %s berhasil disimpan di Redis.", session_id)
+            await r.setex(redis_key, AUTH_TTL_SECONDS, cookie_str)
+            logger.info(
+                "Session %s berhasil disimpan di Redis.",
+                mask_session_id(session_id),
+            )
             return True
     except SiakadAuthError as exc:
         logger.warning(
             "Dependency failure dependency=siakad operation=init_session flow=student mode=auth session_id=%s detail=%s",
-            session_id,
+            mask_session_id(session_id),
             exc.message,
         )
         return False
     except MemoryStoreError as exc:
         logger.error(
             "Dependency failure dependency=redis operation=setex_siakad_session flow=student mode=cache_write session_id=%s detail=%s",
-            session_id,
+            mask_session_id(session_id),
             exc.message,
         )
         return False
     except Exception as exc:
         logger.error(
             "Dependency failure dependency=siakad operation=init_session flow=student mode=unexpected session_id=%s error=%s",
-            session_id,
+            mask_session_id(session_id),
             exc,
             exc_info=True,
         )
+        return False
+
+
+async def issue_student_access_token(session_id: str) -> str:
+    """Generate and store hashed student access token bound to session_id."""
+    token = secrets.token_urlsafe(32)
+    hashed = _hash_access_token(token)
+    try:
+        r = await get_redis()
+        await r.setex(_auth_key(session_id), AUTH_TTL_SECONDS, hashed)
+    except Exception as exc:
+        raise MemoryStoreError("Failed to persist student auth binding") from exc
+    return token
+
+
+async def has_student_access_binding(session_id: str) -> bool:
+    """Whether session_id is bound to an authenticated student session."""
+    try:
+        r = await get_redis()
+        return await r.exists(_auth_key(session_id)) == 1
+    except Exception:
+        return False
+
+
+async def verify_student_access_token(session_id: str, token: str | None) -> bool:
+    """Validate student token against stored hash for the given session."""
+    if not token:
+        return False
+    try:
+        r = await get_redis()
+        expected_hash = await r.get(_auth_key(session_id))
+        if not expected_hash:
+            return False
+        provided_hash = _hash_access_token(token)
+        return hmac.compare_digest(expected_hash, provided_hash)
+    except Exception:
         return False
 
 
@@ -170,7 +223,7 @@ async def get_siakad_cookies(session_id: str) -> dict | None:
     except Exception as exc:
         logger.warning(
             "Dependency failure dependency=redis operation=get_siakad_cookies flow=student mode=read session_id=%s error=%s",
-            session_id,
+            mask_session_id(session_id),
             exc,
         )
         return None
@@ -182,11 +235,16 @@ async def cache_student_data(session_id: str, student_data: dict) -> bool:
         r = await get_redis()
         redis_key = f"student_data:{session_id}"
         await r.setex(redis_key, 3600, json.dumps(student_data))
-        logger.debug("Berhasil cache student_data untuk session_id=%s", session_id)
+        logger.debug(
+            "Berhasil cache student_data untuk session_id=%s",
+            mask_session_id(session_id),
+        )
         return True
     except Exception as e:
         logger.warning(
-            "Redis unavailable saat set cache student_data untuk %s: %s", session_id, e
+            "Redis unavailable saat set cache student_data untuk %s: %s",
+            mask_session_id(session_id),
+            e,
         )
         return False
 
@@ -202,6 +260,8 @@ async def get_cached_student_data(session_id: str) -> dict | None:
         return None
     except Exception as e:
         logger.warning(
-            "Redis unavailable saat get cache student_data untuk %s: %s", session_id, e
+            "Redis unavailable saat get cache student_data untuk %s: %s",
+            mask_session_id(session_id),
+            e,
         )
         return None

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -1,0 +1,36 @@
+"""Security/privacy helpers for API policies and logging."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def mask_session_id(session_id: str | None) -> str:
+    """Return a short non-reversible identifier for logs."""
+    if not session_id:
+        return "none"
+    digest = hashlib.sha256(session_id.encode()).hexdigest()
+    return digest[:10]
+
+
+def mask_email(email: str | None) -> str:
+    """Mask email local-part while preserving domain for diagnostics."""
+    if not email or "@" not in email:
+        return "unknown"
+    local, domain = email.split("@", 1)
+    if len(local) <= 2:
+        masked_local = "*" * len(local)
+    else:
+        masked_local = f"{local[0]}{'*' * (len(local) - 2)}{local[-1]}"
+    return f"{masked_local}@{domain}"
+
+
+def parse_cors_origins(raw: str) -> list[str]:
+    """Parse comma-separated CORS origins from config."""
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+def is_local_env(app_env: str) -> bool:
+    """Whether environment is local/dev style."""
+    return app_env in {"development", "dev", "local", "test"}
+

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,48 @@
+## Security Policy (Public vs Student Flows)
+
+This document defines trust boundaries and enforcement for API routes.
+
+### Route Policy
+
+- `POST /chat`
+  - public route for generic/admin chat
+  - rate limited (`CHAT_RATE_LIMIT`)
+  - if a session is student-bound, request must include `X-Student-Access-Token`
+- `GET /chat/{session_id}/history`
+  - public for non-student sessions
+  - if session is student-bound, requires `X-Student-Access-Token`
+- `POST /auth/login`
+  - public route (credential exchange with SIAKAD)
+  - rate limited (`AUTH_LOGIN_RATE_LIMIT`)
+  - returns:
+    - `session_id`
+    - `student_access_token`
+- `POST /ingest`
+  - operator route
+  - in non-local env (`APP_ENV` not local/dev/test), `INGEST_API_KEY` must be configured
+  - request must send `X-Ingest-Token` matching `INGEST_API_KEY`
+  - rate limited (`INGEST_RATE_LIMIT`)
+
+### Session Trust Semantics
+
+`session_id` is not sufficient by itself for student-data access.
+
+For authenticated student sessions:
+- login stores a server-side auth binding (`siakad_auth:{session_id}`) in Redis
+- client receives a one-time generated `student_access_token`
+- chat/history endpoints verify token hash using `session_id` binding
+- without valid token, student-bound sessions are rejected with `401`
+
+### Logging Rules
+
+Sensitive values are not logged in raw form:
+- session IDs are hashed/truncated for log correlation
+- email addresses are masked
+- chat logs use message length, not message content
+
+### CORS Rules
+
+- wildcard CORS is blocked outside local/dev/test environments
+- local default allows localhost origins when `CORS_ALLOW_ORIGINS` is empty
+- non-local environments must explicitly set allowed origins
+

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+from app.main import app
+from app.services.rate_limiter import reset_rate_limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    reset_rate_limiter()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.asyncio
+async def test_chat_requires_student_access_token_for_student_bound_session():
+    valid_session_id = str(uuid.uuid4())
+
+    with (
+        patch("app.api.chat.has_student_access_binding", new_callable=AsyncMock) as mock_has,
+        patch(
+            "app.api.chat.verify_student_access_token",
+            new_callable=AsyncMock,
+        ) as mock_verify,
+    ):
+        mock_has.return_value = True
+        mock_verify.return_value = False
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/chat",
+                json={"session_id": valid_session_id, "message": "cek nilai saya"},
+            )
+
+    assert resp.status_code == 401
+    assert "token" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_chat_allows_student_bound_session_with_valid_access_token():
+    valid_session_id = str(uuid.uuid4())
+    mock_result = {"answer": "ok", "sources": []}
+
+    with (
+        patch("app.api.chat.has_student_access_binding", new_callable=AsyncMock) as mock_has,
+        patch(
+            "app.api.chat.verify_student_access_token",
+            new_callable=AsyncMock,
+        ) as mock_verify,
+        patch("app.api.chat._get_graph") as mock_get_graph,
+    ):
+        mock_has.return_value = True
+        mock_verify.return_value = True
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke.return_value = mock_result
+        mock_get_graph.return_value = mock_graph
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/chat",
+                json={"session_id": valid_session_id, "message": "cek nilai saya"},
+                headers={"X-Student-Access-Token": "valid"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json()["answer"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ingest_disabled_without_key_in_non_local_env():
+    fake_settings = SimpleNamespace(
+        app_env="production",
+        ingest_api_key=None,
+        ingest_rate_limit=5,
+        rate_limit_window_seconds=60,
+    )
+
+    with patch("app.api.ingest.get_settings", return_value=fake_settings):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/ingest",
+                files={"file": ("a.md", b"# test", "text/markdown")},
+            )
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_ingest_requires_token_when_configured():
+    fake_settings = SimpleNamespace(
+        app_env="production",
+        ingest_api_key="top-secret",
+        ingest_rate_limit=5,
+        rate_limit_window_seconds=60,
+    )
+
+    with patch("app.api.ingest.get_settings", return_value=fake_settings):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/ingest",
+                files={"file": ("a.md", b"# test", "text/markdown")},
+            )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_chat_rate_limited():
+    fake_settings = SimpleNamespace(
+        chat_rate_limit=1,
+        rate_limit_window_seconds=60,
+    )
+    mock_result = {"answer": "ok", "sources": []}
+
+    with (
+        patch("app.api.chat.get_settings", return_value=fake_settings),
+        patch("app.api.chat._get_graph") as mock_get_graph,
+    ):
+        mock_graph = AsyncMock()
+        mock_graph.ainvoke.return_value = mock_result
+        mock_get_graph.return_value = mock_graph
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.post("/chat", json={"message": "hi"})
+            second = await client.post("/chat", json={"message": "again"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+

--- a/tests/test_siakad_session.py
+++ b/tests/test_siakad_session.py
@@ -7,7 +7,10 @@ from app.services.siakad_session import (
     cache_student_data,
     get_cached_student_data,
     get_siakad_cookies,
+    has_student_access_binding,
     init_siakad_session,
+    issue_student_access_token,
+    verify_student_access_token,
 )
 
 
@@ -174,3 +177,25 @@ async def test_get_cached_student_data__redis_error(mock_redis):
     mock_redis.get.side_effect = Exception("redis out of memory")
     res = await get_cached_student_data("sess-12")
     assert res is None
+
+
+@pytest.mark.asyncio
+async def test_issue_and_verify_student_access_token(mock_redis):
+    token = await issue_student_access_token("sess-13")
+    assert isinstance(token, str)
+    assert len(token) > 20
+
+    # Ensure verification works with stored hash.
+    stored_hash = mock_redis.setex.call_args[0][2]
+    mock_redis.get.return_value = stored_hash
+    is_valid = await verify_student_access_token("sess-13", token)
+    assert is_valid is True
+
+
+@pytest.mark.asyncio
+async def test_has_student_access_binding(mock_redis):
+    mock_redis.exists.return_value = 1
+    assert await has_student_access_binding("sess-14") is True
+
+    mock_redis.exists.return_value = 0
+    assert await has_student_access_binding("sess-14") is False


### PR DESCRIPTION
Summary:
- enforce environment-aware CORS and remove wildcard behavior outside local/dev/test
- add explicit ingest access policy (X-Ingest-Token + env gating) and route-level rate limits
- strengthen student session trust by introducing student_access_token binding per session
- require student access token on /chat and /chat/{session_id}/history for student-bound sessions
- reduce sensitive logging via session/email masking helpers
- document route trust model and security controls

Testing:
- uv run pytest (99 passed)

Notes:
- /auth/login now returns student_access_token in addition to session_id
- new security config variables documented in .env.example