### PR TITLE
feat(chunk-crud): implement create, update, and delete chunk endpoints

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -125,6 +125,22 @@ class FileListResponse(BaseModel):
     files: list[FileEntry]
 
 
+class FileDeleteRequest(BaseModel):
+    """Request payload for deleting an ingested file."""
+
+    doc_id: str = Field(..., description="Document ID to delete")
+
+
+class FileDeleteResponse(BaseModel):
+    """Response payload after deleting an ingested file."""
+
+    doc_id: str
+    filename: str
+    deleted_chunks: int
+    deleted: bool
+    message: str = "File and all associated chunks deleted successfully"
+
+
 class IngestResponse(BaseModel):
     doc_id: str
     filename: str
@@ -150,6 +166,8 @@ __all__ = [
     "ChatRequest",
     "ChatResponse",
     "ErrorResponse",
+    "FileDeleteRequest",
+    "FileDeleteResponse",
     "FileEntry",
     "FileListResponse",
     "HealthResponse",

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -141,6 +141,46 @@ class FileDeleteResponse(BaseModel):
     message: str = "File and all associated chunks deleted successfully"
 
 
+class ChunkEntry(BaseModel):
+    """Represents a single chunk from an ingested file."""
+
+    chunk_id: str
+    chunk_index: int
+    page: int | None = None
+    headings: list[str] = Field(default_factory=list)
+    content_type: str = "text"
+    doc_category: str | None = None
+    academic_year: str | None = None
+    text: str
+    enriched_text: str | None = None
+
+
+class ChunkListResponse(BaseModel):
+    """Response payload for listing chunks of an ingested file."""
+
+    doc_id: str
+    filename: str
+    total_chunks: int
+    chunks: list[ChunkEntry]
+
+
+class FileRenameRequest(BaseModel):
+    """Request payload for renaming an ingested file."""
+
+    doc_id: str = Field(..., description="Document ID to rename")
+    filename: str = Field(..., min_length=1, description="New filename")
+
+
+class FileRenameResponse(BaseModel):
+    """Response payload after renaming an ingested file."""
+
+    doc_id: str
+    filename: str
+    updated_chunks: int
+    updated: bool
+    message: str = "Filename updated successfully"
+
+
 class IngestResponse(BaseModel):
     doc_id: str
     filename: str
@@ -165,11 +205,15 @@ __all__ = [
     "ChatHistoryResponse",
     "ChatRequest",
     "ChatResponse",
+    "ChunkEntry",
+    "ChunkListResponse",
     "ErrorResponse",
     "FileDeleteRequest",
     "FileDeleteResponse",
     "FileEntry",
     "FileListResponse",
+    "FileRenameRequest",
+    "FileRenameResponse",
     "HealthResponse",
     "IngestResponse",
     "LoginRequest",

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -191,6 +191,255 @@ class IngestResponse(BaseModel):
     message: str = "Document ingested successfully"
 
 
+# ── Chunk CRUD ──────────────────────────────────────────
+
+
+class ChunkCreateRequest(BaseModel):
+    """Request payload for injecting a new chunk into an existing file."""
+
+    doc_id: str = Field(..., description="Document ID to inject chunk into")
+    text: str = Field(..., min_length=1, description="Chunk text content")
+    chunk_index: int = Field(..., ge=0, description="Chunk index position")
+    page: int | None = Field(default=None, description="Page number")
+    headings: list[str] = Field(default_factory=list, description="Section headings")
+    content_type: str = Field(default="text", description="Content type")
+    doc_category: str | None = Field(default=None, description="Document category")
+    academic_year: str | None = Field(default=None, description="Academic year")
+
+    @field_validator("text")
+    @classmethod
+    def check_text_not_empty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Chunk text cannot be empty or whitespace.")
+        return s
+
+
+class ChunkCreateResponse(BaseModel):
+    """Response payload after injecting a new chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    created: bool
+    message: str = "Chunk injected successfully"
+
+
+class ChunkUpdateRequest(BaseModel):
+    """Request payload for updating an existing chunk."""
+
+    doc_id: str = Field(..., description="Document ID containing the chunk")
+    chunk_index: int = Field(..., ge=0, description="Chunk index to update")
+    text: str = Field(..., min_length=1, description="Updated chunk text content")
+    headings: list[str] | None = Field(default=None, description="Updated headings")
+    page: int | None = Field(default=None, description="Updated page number")
+    content_type: str | None = Field(default=None, description="Updated content type")
+
+    @field_validator("text")
+    @classmethod
+    def check_text_not_empty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Chunk text cannot be empty or whitespace.")
+        return s
+
+
+class ChunkUpdateResponse(BaseModel):
+    """Response payload after updating a chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    updated: bool
+    message: str = "Chunk updated successfully"
+
+
+class ChunkDeleteRequest(BaseModel):
+    """Request payload for deleting a specific chunk."""
+
+    doc_id: str = Field(..., description="Document ID containing the chunk")
+    chunk_index: int = Field(..., ge=0, description="Chunk index to delete")
+
+
+class ChunkDeleteResponse(BaseModel):
+    """Response payload after deleting a chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    deleted: bool
+    message: str = "Chunk deleted successfully"
+
+
+# ── Chunk CRUD ──────────────────────────────────────────
+
+
+class ChunkCreateRequest(BaseModel):
+    """Request payload for injecting a new chunk into an existing file."""
+
+    doc_id: str = Field(..., description="Document ID to inject chunk into")
+    text: str = Field(..., min_length=1, description="Chunk text content")
+    chunk_index: int = Field(..., ge=0, description="Chunk index position")
+    page: int | None = Field(default=None, description="Page number")
+    headings: list[str] = Field(default_factory=list, description="Section headings")
+    content_type: str = Field(default="text", description="Content type")
+    doc_category: str | None = Field(default=None, description="Document category")
+    academic_year: str | None = Field(default=None, description="Academic year")
+
+    @field_validator("text")
+    @classmethod
+    def check_text_not_empty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Chunk text cannot be empty or whitespace.")
+        return s
+
+
+class ChunkCreateResponse(BaseModel):
+    """Response payload after injecting a new chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    created: bool
+    message: str = "Chunk injected successfully"
+
+
+class ChunkUpdateRequest(BaseModel):
+    """Request payload for updating an existing chunk."""
+
+    doc_id: str = Field(..., description="Document ID containing the chunk")
+    chunk_index: int = Field(..., ge=0, description="Chunk index to update")
+    text: str = Field(..., min_length=1, description="Updated chunk text content")
+    headings: list[str] | None = Field(default=None, description="Updated headings")
+    page: int | None = Field(default=None, description="Updated page number")
+    content_type: str | None = Field(default=None, description="Updated content type")
+
+    @field_validator("text")
+    @classmethod
+    def check_text_not_empty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Chunk text cannot be empty or whitespace.")
+        return s
+
+
+class ChunkUpdateResponse(BaseModel):
+    """Response payload after updating a chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    updated: bool
+    message: str = "Chunk updated successfully"
+
+
+class ChunkDeleteRequest(BaseModel):
+    """Request payload for deleting a specific chunk."""
+
+    doc_id: str = Field(..., description="Document ID containing the chunk")
+    chunk_index: int = Field(..., ge=0, description="Chunk index to delete")
+
+
+class ChunkDeleteResponse(BaseModel):
+    """Response payload after deleting a chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    deleted: bool
+    message: str = "Chunk deleted successfully"
+
+
+# ── Chunk CRUD ──────────────────────────────────────────
+
+
+class ChunkCreateRequest(BaseModel):
+    """Request payload for injecting a new chunk into an existing file."""
+
+    doc_id: str = Field(..., description="Document ID to inject chunk into")
+    text: str = Field(..., min_length=1, description="Chunk text content")
+    chunk_index: int = Field(..., ge=0, description="Chunk index position")
+    page: int | None = Field(default=None, description="Page number")
+    headings: list[str] = Field(default_factory=list, description="Section headings")
+    content_type: str = Field(default="text", description="Content type")
+    doc_category: str | None = Field(default=None, description="Document category")
+    academic_year: str | None = Field(default=None, description="Academic year")
+
+    @field_validator("text")
+    @classmethod
+    def check_text_not_empty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Chunk text cannot be empty or whitespace.")
+        return s
+
+
+class ChunkCreateResponse(BaseModel):
+    """Response payload after injecting a new chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    created: bool
+    message: str = "Chunk injected successfully"
+
+
+class ChunkUpdateRequest(BaseModel):
+    """Request payload for updating an existing chunk."""
+
+    doc_id: str = Field(..., description="Document ID containing the chunk")
+    chunk_index: int = Field(..., ge=0, description="Chunk index to update")
+    text: str = Field(..., min_length=1, description="Updated chunk text content")
+    headings: list[str] | None = Field(default=None, description="Updated headings")
+    page: int | None = Field(default=None, description="Updated page number")
+    content_type: str | None = Field(default=None, description="Updated content type")
+
+    @field_validator("text")
+    @classmethod
+    def check_text_not_empty(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Chunk text cannot be empty or whitespace.")
+        return s
+
+
+class ChunkUpdateResponse(BaseModel):
+    """Response payload after updating a chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    updated: bool
+    message: str = "Chunk updated successfully"
+
+
+class ChunkDeleteRequest(BaseModel):
+    """Request payload for deleting a specific chunk."""
+
+    doc_id: str = Field(..., description="Document ID containing the chunk")
+    chunk_index: int = Field(..., ge=0, description="Chunk index to delete")
+
+
+class ChunkDeleteResponse(BaseModel):
+    """Response payload after deleting a chunk."""
+
+    doc_id: str
+    filename: str
+    chunk_index: int
+    chunk_id: str
+    deleted: bool
+    message: str = "Chunk deleted successfully"
+
+
 # ── Health ──────────────────────────────────────────────
 
 
@@ -205,8 +454,14 @@ __all__ = [
     "ChatHistoryResponse",
     "ChatRequest",
     "ChatResponse",
+    "ChunkCreateRequest",
+    "ChunkCreateResponse",
+    "ChunkDeleteRequest",
+    "ChunkDeleteResponse",
     "ChunkEntry",
     "ChunkListResponse",
+    "ChunkUpdateRequest",
+    "ChunkUpdateResponse",
     "ErrorResponse",
     "FileDeleteRequest",
     "FileDeleteResponse",

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -108,6 +108,23 @@ class ChatHistoryResponse(BaseModel):
 # ── Ingest ──────────────────────────────────────────────
 
 
+class FileEntry(BaseModel):
+    """Represents a single ingested file in the listing."""
+
+    doc_id: str
+    filename: str
+    doc_category: str | None = None
+    academic_year: str | None = None
+    total_chunks: int
+
+
+class FileListResponse(BaseModel):
+    """Response payload for listing ingested files."""
+
+    total_files: int
+    files: list[FileEntry]
+
+
 class IngestResponse(BaseModel):
     doc_id: str
     filename: str
@@ -133,6 +150,8 @@ __all__ = [
     "ChatRequest",
     "ChatResponse",
     "ErrorResponse",
+    "FileEntry",
+    "FileListResponse",
     "HealthResponse",
     "IngestResponse",
     "LoginRequest",

--- a/app/api/routers/ingestion.py
+++ b/app/api/routers/ingestion.py
@@ -8,9 +8,10 @@ import tempfile
 
 from fastapi import APIRouter, Header, Request, UploadFile
 
-from app.api.models import IngestResponse
+from app.api.models import FileEntry, FileListResponse, IngestResponse
 from app.config import get_settings
 from app.ingestion.pipeline import ingest_document
+from app.services import vectorstore as vs
 from app.services.rate_limiter import allow_request
 from app.utils.exceptions import AppError
 from app.utils.logger import get_logger
@@ -127,6 +128,17 @@ async def _check_rate_limit(client_ip: str, settings: object) -> None:
 # ---------------------------------------------------------------------------
 # Endpoint
 # ---------------------------------------------------------------------------
+
+
+@router.get("/ingest/files", response_model=FileListResponse)
+async def list_files() -> FileListResponse:
+    """List all ingested files with their chunk counts."""
+    raw_files = await vs.list_files()
+    entries = [FileEntry(**f) for f in raw_files]
+    return FileListResponse(
+        total_files=len(entries),
+        files=entries,
+    )
 
 
 @router.post("/ingest", response_model=IngestResponse)

--- a/app/api/routers/ingestion.py
+++ b/app/api/routers/ingestion.py
@@ -9,8 +9,14 @@ import tempfile
 from fastapi import APIRouter, Header, Query, Request, UploadFile
 
 from app.api.models import (
+    ChunkCreateRequest,
+    ChunkCreateResponse,
+    ChunkDeleteRequest,
+    ChunkDeleteResponse,
     ChunkEntry,
     ChunkListResponse,
+    ChunkUpdateRequest,
+    ChunkUpdateResponse,
     FileDeleteRequest,
     FileDeleteResponse,
     FileEntry,
@@ -21,9 +27,11 @@ from app.api.models import (
 )
 from app.config import get_settings
 from app.ingestion.pipeline import ingest_document
+from app.services import embeddings as embed_svc
 from app.services import vectorstore as vs
 from app.services.rate_limiter import allow_request
 from app.utils.exceptions import AppError, VectorStoreError
+from app.utils.helpers import generate_chunk_point_id
 from app.utils.logger import get_logger
 from app.utils.security import is_local_env
 
@@ -212,6 +220,156 @@ async def list_chunks(
         filename=filename,
         total_chunks=len(chunks),
         chunks=chunks,
+    )
+
+
+def _build_enriched_text(text: str, headings: list[str]) -> str:
+    """Build enriched text from headings and text content."""
+    if headings:
+        return f"[{headings[0]}]\n{text}"
+    return text
+
+
+@router.post("/ingest/by-file/chunks", response_model=ChunkCreateResponse)
+async def create_chunk(body: ChunkCreateRequest) -> ChunkCreateResponse:
+    """Inject a manually written chunk into an existing file's chunk inventory."""
+    existing_chunks = await vs.scroll_chunks_by_doc_id(body.doc_id)
+    if not existing_chunks:
+        raise AppError(
+            detail=f"File with doc_id='{body.doc_id}' not found.",
+            status_code=404,
+            title="Not Found",
+        )
+
+    chunk_id = generate_chunk_point_id(body.doc_id, body.chunk_index)
+
+    for point in existing_chunks:
+        payload = point.payload or {}
+        if str(point.id) == chunk_id:
+            raise AppError(
+                detail=f"Chunk at index {body.chunk_index} already exists for doc_id='{body.doc_id}'. Use PATCH to update.",
+                status_code=409,
+                title="Conflict",
+            )
+
+    first_payload = existing_chunks[0].payload or {}
+    filename = first_payload.get("filename", "")
+    doc_category = body.doc_category if body.doc_category is not None else first_payload.get("doc_category")
+    academic_year = body.academic_year if body.academic_year is not None else first_payload.get("academic_year")
+
+    enriched_text = _build_enriched_text(body.text, body.headings)
+    dense_vector = await embed_svc.embed_query(enriched_text)
+    sparse_vector = vs._encode_sparse([enriched_text])[0]
+
+    payload = {
+        "text": body.text,
+        "enriched_text": enriched_text,
+        "doc_id": body.doc_id,
+        "filename": filename,
+        "chunk_index": body.chunk_index,
+        "headings": body.headings,
+        "page": body.page,
+        "doc_category": doc_category,
+        "academic_year": academic_year,
+        "content_type": body.content_type,
+    }
+
+    await vs.upsert_single_chunk(chunk_id, dense_vector, sparse_vector, payload)
+
+    return ChunkCreateResponse(
+        doc_id=body.doc_id,
+        filename=filename,
+        chunk_index=body.chunk_index,
+        chunk_id=chunk_id,
+        created=True,
+        message="Chunk injected successfully",
+    )
+
+
+@router.patch("/ingest/by-file/chunks", response_model=ChunkUpdateResponse)
+async def update_chunk(body: ChunkUpdateRequest) -> ChunkUpdateResponse:
+    """Overwrite the text and optionally metadata of one specific chunk."""
+    existing_chunks = await vs.scroll_chunks_by_doc_id(body.doc_id)
+    if not existing_chunks:
+        raise AppError(
+            detail=f"File with doc_id='{body.doc_id}' not found.",
+            status_code=404,
+            title="Not Found",
+        )
+
+    chunk_data = await vs.get_chunk_by_doc_id_and_index(body.doc_id, body.chunk_index)
+    if chunk_data is None:
+        raise AppError(
+            detail=f"Chunk at index {body.chunk_index} not found for doc_id='{body.doc_id}'.",
+            status_code=404,
+            title="Not Found",
+        )
+
+    chunk_id = chunk_data["point_id"]
+    existing_payload = chunk_data["payload"]
+    filename = existing_payload.get("filename", "")
+
+    merged_payload = dict(existing_payload)
+    merged_payload["text"] = body.text
+
+    if body.headings is not None:
+        merged_payload["headings"] = body.headings
+    if body.page is not None:
+        merged_payload["page"] = body.page
+    if body.content_type is not None:
+        merged_payload["content_type"] = body.content_type
+
+    headings = merged_payload.get("headings", [])
+    enriched_text = _build_enriched_text(body.text, headings)
+    merged_payload["enriched_text"] = enriched_text
+
+    dense_vector = await embed_svc.embed_query(enriched_text)
+    sparse_vector = vs._encode_sparse([enriched_text])[0]
+
+    await vs.upsert_single_chunk(chunk_id, dense_vector, sparse_vector, merged_payload)
+
+    return ChunkUpdateResponse(
+        doc_id=body.doc_id,
+        filename=filename,
+        chunk_index=body.chunk_index,
+        chunk_id=chunk_id,
+        updated=True,
+        message="Chunk updated successfully",
+    )
+
+
+@router.delete("/ingest/by-file/chunks", response_model=ChunkDeleteResponse)
+async def delete_chunk(body: ChunkDeleteRequest) -> ChunkDeleteResponse:
+    """Remove one chunk from an ingested file's inventory."""
+    existing_chunks = await vs.scroll_chunks_by_doc_id(body.doc_id)
+    if not existing_chunks:
+        raise AppError(
+            detail=f"File with doc_id='{body.doc_id}' not found.",
+            status_code=404,
+            title="Not Found",
+        )
+
+    chunk_data = await vs.get_chunk_by_doc_id_and_index(body.doc_id, body.chunk_index)
+    if chunk_data is None:
+        raise AppError(
+            detail=f"Chunk at index {body.chunk_index} not found for doc_id='{body.doc_id}'.",
+            status_code=404,
+            title="Not Found",
+        )
+
+    chunk_id = chunk_data["point_id"]
+    existing_payload = chunk_data["payload"]
+    filename = existing_payload.get("filename", "")
+
+    await vs.delete_single_chunk(chunk_id)
+
+    return ChunkDeleteResponse(
+        doc_id=body.doc_id,
+        filename=filename,
+        chunk_index=body.chunk_index,
+        chunk_id=chunk_id,
+        deleted=True,
+        message="Chunk deleted successfully",
     )
 
 

--- a/app/api/routers/ingestion.py
+++ b/app/api/routers/ingestion.py
@@ -6,13 +6,17 @@ from pathlib import Path
 import shutil
 import tempfile
 
-from fastapi import APIRouter, Header, Request, UploadFile
+from fastapi import APIRouter, Header, Query, Request, UploadFile
 
 from app.api.models import (
+    ChunkEntry,
+    ChunkListResponse,
     FileDeleteRequest,
     FileDeleteResponse,
     FileEntry,
     FileListResponse,
+    FileRenameRequest,
+    FileRenameResponse,
     IngestResponse,
 )
 from app.config import get_settings
@@ -167,6 +171,80 @@ async def delete_file(body: FileDeleteRequest) -> FileDeleteResponse:
         deleted_chunks=result["deleted_chunks"],
         deleted=True,
         message="File and all associated chunks deleted successfully",
+    )
+
+
+@router.get("/ingest/by-file/chunks", response_model=ChunkListResponse)
+async def list_chunks(
+    doc_id: str = Query(..., description="Document ID to list chunks for"),
+) -> ChunkListResponse:
+    """List all chunks for an ingested file, sorted by chunk_index."""
+    points = await vs.scroll_chunks_by_doc_id(doc_id)
+
+    if not points:
+        raise AppError(
+            detail=f"File with doc_id='{doc_id}' not found.",
+            status_code=404,
+            title="Not Found",
+        )
+
+    chunks: list[ChunkEntry] = []
+    filename = ""
+    for point in points:
+        p = point.payload or {}
+        filename = p.get("filename", "")
+        chunks.append(
+            ChunkEntry(
+                chunk_id=str(point.id),
+                chunk_index=p["chunk_index"],
+                page=p.get("page"),
+                headings=p.get("headings", []),
+                content_type=p.get("content_type", "text"),
+                doc_category=p.get("doc_category"),
+                academic_year=p.get("academic_year"),
+                text=p["text"],
+                enriched_text=p.get("enriched_text"),
+            )
+        )
+
+    return ChunkListResponse(
+        doc_id=doc_id,
+        filename=filename,
+        total_chunks=len(chunks),
+        chunks=chunks,
+    )
+
+
+@router.patch("/ingest/files", response_model=FileRenameResponse)
+async def rename_file(body: FileRenameRequest) -> FileRenameResponse:
+    """Rename an ingested file by updating its filename payload."""
+    # Check for filename collision with another doc_id
+    existing_files = await vs.list_files()
+    for f in existing_files:
+        if f["filename"] == body.filename and f["doc_id"] != body.doc_id:
+            raise AppError(
+                detail=f"Filename '{body.filename}' is already used by doc_id='{f['doc_id']}'.",
+                status_code=409,
+                title="Conflict",
+            )
+
+    try:
+        result = await vs.rename_file(body.doc_id, body.filename)
+    except VectorStoreError as exc:
+        if "not found" in str(exc).lower():
+            raise AppError(
+                detail=f"File with doc_id='{body.doc_id}' not found.",
+                status_code=404,
+                title="Not Found",
+            ) from exc
+        raise
+
+    return FileRenameResponse(
+        doc_id=result["doc_id"],
+        filename=result["filename"],
+        updated_chunks=result["updated_chunks"],
+        updated=True,
+        message="Filename updated successfully",
     )
 
 

--- a/app/api/routers/ingestion.py
+++ b/app/api/routers/ingestion.py
@@ -8,12 +8,18 @@ import tempfile
 
 from fastapi import APIRouter, Header, Request, UploadFile
 
-from app.api.models import FileEntry, FileListResponse, IngestResponse
+from app.api.models import (
+    FileDeleteRequest,
+    FileDeleteResponse,
+    FileEntry,
+    FileListResponse,
+    IngestResponse,
+)
 from app.config import get_settings
 from app.ingestion.pipeline import ingest_document
 from app.services import vectorstore as vs
 from app.services.rate_limiter import allow_request
-from app.utils.exceptions import AppError
+from app.utils.exceptions import AppError, VectorStoreError
 from app.utils.logger import get_logger
 from app.utils.security import is_local_env
 
@@ -138,6 +144,29 @@ async def list_files() -> FileListResponse:
     return FileListResponse(
         total_files=len(entries),
         files=entries,
+    )
+
+
+@router.delete("/ingest/files", response_model=FileDeleteResponse)
+async def delete_file(body: FileDeleteRequest) -> FileDeleteResponse:
+    """Delete all chunks belonging to an ingested file."""
+    try:
+        result = await vs.delete_file(body.doc_id)
+    except VectorStoreError as exc:
+        # doc_id not found → 404
+        if "not found" in str(exc).lower():
+            raise AppError(
+                detail=f"File with doc_id='{body.doc_id}' not found.",
+                status_code=404,
+                title="Not Found",
+            ) from exc
+        raise
+    return FileDeleteResponse(
+        doc_id=result["doc_id"],
+        filename=result["filename"],
+        deleted_chunks=result["deleted_chunks"],
+        deleted=True,
+        message="File and all associated chunks deleted successfully",
     )
 
 

--- a/app/ingestion/upserter.py
+++ b/app/ingestion/upserter.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import uuid
-
 from app.ingestion.chunker import Chunk
 from app.ingestion.metadata import extract_doc_metadata
 from app.services import embeddings as embed_svc
 from app.services import vectorstore as vs
+from app.utils.helpers import generate_chunk_point_id
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -31,11 +30,6 @@ def _enrich_text(chunk: Chunk) -> str:
         if last_heading:
             return f"[{last_heading}]\n{chunk.text}"
     return chunk.text
-
-
-def generate_point_id() -> str:
-    """Generate a unique point ID for Qdrant."""
-    return str(uuid.uuid4())
 
 
 async def upsert_chunks(
@@ -79,7 +73,7 @@ async def upsert_chunks(
             collection_prepared = True
 
         # Build point data — keep original text for display, enriched for BM25
-        ids = [generate_point_id() for _ in batch]
+        ids = [generate_chunk_point_id(doc_id, c.chunk_index) for c in batch]
         payloads = [
             {
                 "text": c.text,

--- a/app/services/vectorstore.py
+++ b/app/services/vectorstore.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any
 
 from fastembed import SparseTextEmbedding
@@ -271,6 +272,76 @@ async def hybrid_search(
 
     logger.debug("Hybrid search returned %d results", len(docs))
     return docs
+
+
+async def list_files() -> list[dict[str, Any]]:
+    """List all unique ingested files with their chunk counts.
+
+    Scrolls all points in the collection, deduplicates by ``doc_id``,
+    and returns one entry per file with metadata extracted from chunk payloads.
+
+    Returns a list of dicts sorted by filename ascending, each containing:
+    - doc_id
+    - filename
+    - doc_category
+    - academic_year
+    - total_chunks
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    # Scroll all points — Option A (dev/small scale)
+    # Using a large enough limit to fetch everything in one go
+    start_ms = now_ms()
+    try:
+        points, _next_offset = await client.scroll(
+            collection_name=settings.collection_name,
+            limit=100_000,
+            with_payload=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=scroll mode=unexpected latency_ms=%.1f",
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to list files from Qdrant") from exc
+
+    # Deduplicate by doc_id and count chunks per doc_id
+    doc_map: dict[str, dict[str, Any]] = {}
+    chunk_counts: dict[str, int] = defaultdict(int)
+
+    for point in points:
+        payload = point.payload or {}
+        doc_id = payload.get("doc_id")
+        if doc_id is None:
+            continue
+
+        chunk_counts[doc_id] += 1
+
+        if doc_id not in doc_map:
+            doc_map[doc_id] = {
+                "doc_id": doc_id,
+                "filename": payload.get("filename", ""),
+                "doc_category": payload.get("doc_category"),
+                "academic_year": payload.get("academic_year"),
+            }
+
+    # Build the result with total_chunks
+    files = []
+    for doc_id, meta in doc_map.items():
+        files.append(
+            {
+                **meta,
+                "total_chunks": chunk_counts[doc_id],
+            }
+        )
+
+    # Sort by filename ascending for stable ordering
+    files.sort(key=lambda f: f["filename"])
+
+    logger.info("Listed %d unique files from Qdrant", len(files))
+    return files
 
 
 async def close_client() -> None:

--- a/app/services/vectorstore.py
+++ b/app/services/vectorstore.py
@@ -424,6 +424,171 @@ async def delete_file(doc_id: str) -> dict[str, Any]:
     }
 
 
+async def scroll_chunks_by_doc_id(doc_id: str) -> list[dict[str, Any]]:
+    """Scroll all chunks for a given ``doc_id``, handling full pagination.
+
+    Uses Qdrant scroll with offset-based pagination until ``next_offset`` is
+    ``None``. Returns all points sorted by ``chunk_index``.
+
+    Raises:
+        VectorStoreError: If the query fails.
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    scroll_filter = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="doc_id",
+                match=models.MatchValue(value=doc_id),
+            )
+        ]
+    )
+
+    all_points: list[models.Record] = []
+    offset = None
+
+    start_ms = now_ms()
+    try:
+        while True:
+            results, next_offset = await client.scroll(
+                collection_name=settings.collection_name,
+                scroll_filter=scroll_filter,
+                limit=100,
+                offset=offset,
+                with_payload=True,
+                with_vectors=False,
+            )
+            all_points.extend(results)
+            if next_offset is None:
+                break
+            offset = next_offset
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=scroll_chunks mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to retrieve chunks from Qdrant") from exc
+
+    # Sort by chunk_index for stable ordering
+    def _chunk_index(point: models.Record) -> int:
+        payload = point.payload or {}
+        return payload.get("chunk_index", 0)
+
+    all_points.sort(key=_chunk_index)
+
+    logger.info("Scrolled %d chunks for doc_id=%s", len(all_points), doc_id)
+    return all_points
+
+
+async def rename_file(doc_id: str, new_filename: str) -> dict[str, Any]:
+    """Update the filename payload across all chunks for a given ``doc_id``.
+
+    Uses Qdrant ``set_payload`` with a filter to update all matching points
+    in a single call. Returns the count of updated chunks.
+
+    Raises:
+        VectorStoreError: If the doc_id is not found or the operation fails.
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    # Step 1: Count existing chunks to return in response
+    start_ms = now_ms()
+    try:
+        points, _next_offset = await client.scroll(
+            collection_name=settings.collection_name,
+            scroll_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="doc_id",
+                        match=models.MatchValue(value=doc_id),
+                    )
+                ]
+            ),
+            limit=1,
+            with_payload=False,
+            with_vectors=False,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=scroll_rename mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to query file before rename") from exc
+
+    if len(points) == 0:
+        raise VectorStoreError(f"File with doc_id='{doc_id}' not found")
+
+    # Step 2: Count total chunks for this doc_id
+    start_ms = now_ms()
+    try:
+        count_result = await client.count(
+            collection_name=settings.collection_name,
+            count_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="doc_id",
+                        match=models.MatchValue(value=doc_id),
+                    )
+                ]
+            ),
+            exact=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=count_rename mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to count chunks before rename") from exc
+
+    chunk_count = count_result.count
+
+    # Step 3: Apply set_payload with filter
+    points_filter = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="doc_id",
+                match=models.MatchValue(value=doc_id),
+            )
+        ]
+    )
+
+    start_ms = now_ms()
+    try:
+        await client.set_payload(
+            collection_name=settings.collection_name,
+            payload={"filename": new_filename},
+            points=points_filter,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=set_payload_rename mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to update filename in Qdrant") from exc
+
+    logger.info(
+        "Renamed file doc_id=%s to '%s' across %d chunks",
+        doc_id,
+        new_filename,
+        chunk_count,
+    )
+    return {
+        "doc_id": doc_id,
+        "filename": new_filename,
+        "updated_chunks": chunk_count,
+    }
+
+
 async def close_client() -> None:
     """Close the Qdrant client."""
     global _client

--- a/app/services/vectorstore.py
+++ b/app/services/vectorstore.py
@@ -589,6 +589,232 @@ async def rename_file(doc_id: str, new_filename: str) -> dict[str, Any]:
     }
 
 
+async def get_chunk_by_doc_id_and_index(
+    doc_id: str, chunk_index: int
+) -> dict[str, Any] | None:
+    """Fetch a single chunk by doc_id and chunk_index.
+
+    Returns the point payload dict if found, else None.
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    scroll_filter = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="doc_id",
+                match=models.MatchValue(value=doc_id),
+            ),
+            models.FieldCondition(
+                key="chunk_index",
+                match=models.MatchValue(value=chunk_index),
+            ),
+        ]
+    )
+
+    start_ms = now_ms()
+    try:
+        points, _next_offset = await client.scroll(
+            collection_name=settings.collection_name,
+            scroll_filter=scroll_filter,
+            limit=1,
+            with_payload=True,
+            with_vectors=False,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=get_chunk mode=unexpected doc_id=%s chunk_index=%d latency_ms=%.1f",
+            doc_id,
+            chunk_index,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to retrieve chunk from Qdrant") from exc
+
+    if not points:
+        return None
+
+    return {"point_id": str(points[0].id), "payload": points[0].payload or {}}
+
+
+async def upsert_single_chunk(
+    point_id: str,
+    dense_vector: list[float],
+    sparse_vector: models.SparseVector,
+    payload: dict[str, Any],
+) -> None:
+    """Upsert a single chunk point with dense and sparse vectors."""
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    point = models.PointStruct(
+        id=point_id,
+        vector={
+            "dense": dense_vector,
+            "bm25": sparse_vector,
+        },
+        payload=payload,
+    )
+
+    start_ms = now_ms()
+    try:
+        await client.upsert(
+            collection_name=settings.collection_name,
+            points=[point],
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=upsert_single_chunk mode=unexpected point_id=%s latency_ms=%.1f",
+            point_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to upsert chunk to Qdrant") from exc
+
+    logger.info("Upserted single chunk point_id=%s", point_id)
+
+
+async def delete_single_chunk(point_id: str) -> bool:
+    """Delete a single chunk point by its ID.
+
+    Returns True if a point was deleted, False if it didn't exist.
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    start_ms = now_ms()
+    try:
+        await client.delete(
+            collection_name=settings.collection_name,
+            points=[point_id],
+            wait=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=delete_single_chunk mode=unexpected point_id=%s latency_ms=%.1f",
+            point_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to delete chunk from Qdrant") from exc
+
+    logger.info("Deleted single chunk point_id=%s", point_id)
+    return True
+
+
+async def get_chunk_by_doc_id_and_index(
+    doc_id: str, chunk_index: int
+) -> dict[str, Any] | None:
+    """Fetch a single chunk by doc_id and chunk_index.
+
+    Returns the point payload dict if found, else None.
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    scroll_filter = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="doc_id",
+                match=models.MatchValue(value=doc_id),
+            ),
+            models.FieldCondition(
+                key="chunk_index",
+                match=models.MatchValue(value=chunk_index),
+            ),
+        ]
+    )
+
+    start_ms = now_ms()
+    try:
+        points, _next_offset = await client.scroll(
+            collection_name=settings.collection_name,
+            scroll_filter=scroll_filter,
+            limit=1,
+            with_payload=True,
+            with_vectors=False,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=get_chunk mode=unexpected doc_id=%s chunk_index=%d latency_ms=%.1f",
+            doc_id,
+            chunk_index,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to retrieve chunk from Qdrant") from exc
+
+    if not points:
+        return None
+
+    return {"point_id": str(points[0].id), "payload": points[0].payload or {}}
+
+
+async def upsert_single_chunk(
+    point_id: str,
+    dense_vector: list[float],
+    sparse_vector: models.SparseVector,
+    payload: dict[str, Any],
+) -> None:
+    """Upsert a single chunk point with dense and sparse vectors."""
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    point = models.PointStruct(
+        id=point_id,
+        vector={
+            "dense": dense_vector,
+            "bm25": sparse_vector,
+        },
+        payload=payload,
+    )
+
+    start_ms = now_ms()
+    try:
+        await client.upsert(
+            collection_name=settings.collection_name,
+            points=[point],
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=upsert_single_chunk mode=unexpected point_id=%s latency_ms=%.1f",
+            point_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to upsert chunk to Qdrant") from exc
+
+    logger.info("Upserted single chunk point_id=%s", point_id)
+
+
+async def delete_single_chunk(point_id: str) -> bool:
+    """Delete a single chunk point by its ID.
+
+    Returns True if a point was deleted, False if it didn't exist.
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    start_ms = now_ms()
+    try:
+        await client.delete(
+            collection_name=settings.collection_name,
+            points=[point_id],
+            wait=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=delete_single_chunk mode=unexpected point_id=%s latency_ms=%.1f",
+            point_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to delete chunk from Qdrant") from exc
+
+    logger.info("Deleted single chunk point_id=%s", point_id)
+    return True
+
+
 async def close_client() -> None:
     """Close the Qdrant client."""
     global _client

--- a/app/services/vectorstore.py
+++ b/app/services/vectorstore.py
@@ -344,6 +344,86 @@ async def list_files() -> list[dict[str, Any]]:
     return files
 
 
+async def delete_file(doc_id: str) -> dict[str, Any]:
+    """Delete all chunks belonging to a single ingested file.
+
+    First counts the chunks and extracts metadata, then performs the deletion.
+    Returns a dict with doc_id, filename, deleted_chunks count.
+
+    Raises:
+        VectorStoreError: If the doc_id is not found (to be mapped to 404).
+    """
+    settings = get_settings()
+    client = await get_qdrant_client()
+
+    # Step 1: Count chunks and get metadata before deletion
+    start_ms = now_ms()
+    try:
+        points, _next_offset = await client.scroll(
+            collection_name=settings.collection_name,
+            scroll_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="doc_id",
+                        match=models.MatchValue(value=doc_id),
+                    )
+                ]
+            ),
+            limit=100_000,
+            with_payload=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=scroll_delete mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to query file before deletion") from exc
+
+    chunk_count = len(points)
+    if chunk_count == 0:
+        raise VectorStoreError(f"File with doc_id='{doc_id}' not found")
+
+    # Extract filename from the first point's payload
+    filename = points[0].payload.get("filename", "") if points[0].payload else ""
+
+    # Step 2: Delete all points matching doc_id
+    selector = models.Filter(
+        must=[
+            models.FieldCondition(
+                key="doc_id",
+                match=models.MatchValue(value=doc_id),
+            )
+        ]
+    )
+
+    start_ms = now_ms()
+    try:
+        await client.delete(
+            collection_name=settings.collection_name,
+            points_selector=selector,
+            wait=True,
+        )
+    except Exception as exc:
+        logger.error(
+            "Dependency failure dependency=qdrant operation=delete_file mode=unexpected doc_id=%s latency_ms=%.1f",
+            doc_id,
+            elapsed_ms(start_ms),
+            exc_info=True,
+        )
+        raise VectorStoreError("Failed to delete file from Qdrant") from exc
+
+    logger.info(
+        "Deleted file doc_id=%s (%s) with %d chunks", doc_id, filename, chunk_count
+    )
+    return {
+        "doc_id": doc_id,
+        "filename": filename,
+        "deleted_chunks": chunk_count,
+    }
+
+
 async def close_client() -> None:
     """Close the Qdrant client."""
     global _client

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -13,9 +13,9 @@ def generate_doc_id(filename: str) -> str:
 
 
 def generate_chunk_point_id(doc_id: str, chunk_index: int) -> str:
-    """Deterministic chunk point ID from document identity + chunk index."""
+    """Generate a deterministic UUID from document identity + chunk index."""
     raw = f"{doc_id}:{chunk_index}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:24]
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, raw))
 
 
 def generate_point_id() -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -244,6 +244,119 @@ async def test_list_files_idempotent_reingest():
 
 
 @pytest.mark.asyncio
+async def test_delete_file_success():
+    """Delete endpoint removes a file and returns chunk count."""
+    delete_result = {
+        "doc_id": "doc-abc123",
+        "filename": "enrollment.pdf",
+        "deleted_chunks": 5,
+    }
+
+    with patch("app.api.routers.ingestion.vs.delete_file") as mock_delete:
+        mock_delete.return_value = delete_result
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE", "/ingest/files", json={"doc_id": "doc-abc123"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["doc_id"] == "doc-abc123"
+        assert data["filename"] == "enrollment.pdf"
+        assert data["deleted_chunks"] == 5
+        assert data["deleted"] is True
+        assert "deleted successfully" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_delete_file_not_found():
+    """Delete endpoint returns 404 for unknown doc_id."""
+    from app.utils.exceptions import VectorStoreError
+
+    with patch("app.api.routers.ingestion.vs.delete_file") as mock_delete:
+        mock_delete.side_effect = VectorStoreError(
+            "File with doc_id='unknown-id' not found"
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE", "/ingest/files", json={"doc_id": "unknown-id"}
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+    assert "not found" in data["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_twice_returns_404():
+    """Deleting the same doc_id twice returns 404 on second call."""
+    from app.utils.exceptions import VectorStoreError
+
+    # First delete succeeds
+    first_result = {
+        "doc_id": "doc-to-delete",
+        "filename": "remove-me.pdf",
+        "deleted_chunks": 3,
+    }
+
+    with patch("app.api.routers.ingestion.vs.delete_file") as mock_delete:
+        mock_delete.return_value = first_result
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE", "/ingest/files", json={"doc_id": "doc-to-delete"}
+            )
+
+        assert response.status_code == 200
+
+    # Second delete fails
+    with patch("app.api.routers.ingestion.vs.delete_file") as mock_delete:
+        mock_delete.side_effect = VectorStoreError(
+            "File with doc_id='doc-to-delete' not found"
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE", "/ingest/files", json={"doc_id": "doc-to-delete"}
+            )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_no_other_files_affected():
+    """Deleting one file does not remove chunks from other files."""
+    # Simulates that only the target doc_id's chunks are deleted
+    delete_result = {
+        "doc_id": "doc-target",
+        "filename": "target.pdf",
+        "deleted_chunks": 7,
+    }
+
+    with patch("app.api.routers.ingestion.vs.delete_file") as mock_delete:
+        mock_delete.return_value = delete_result
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE", "/ingest/files", json={"doc_id": "doc-target"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Only target file affected
+        assert data["doc_id"] == "doc-target"
+        assert data["deleted_chunks"] == 7
+
+
+@pytest.mark.asyncio
 async def test_ingest_unsupported_file():
     """Ingest endpoint rejects unsupported file types with RFC 7807 error."""
     transport = ASGITransport(app=app)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import ASGITransport, AsyncClient
 import pytest
@@ -653,3 +653,763 @@ async def test_ingest_rejects_file_over_size_limit():
 
     assert response.status_code == 413
     _assert_rfc7807(response.json(), 413, "Payload Too Large")
+
+
+# ── Chunk Create (Issue 2) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_success():
+    """Create chunk endpoint injects a new chunk and returns success."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-001",
+            payload={
+                "chunk_index": 0,
+                "filename": "test.pdf",
+                "text": "existing chunk",
+                "doc_category": "guide",
+                "academic_year": "2024/2025",
+            },
+        ),
+    ]
+
+    chunk_id = generate_chunk_point_id("doc-test", 22)
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "text": "Injected chunk text",
+                    "chunk_index": 22,
+                    "page": 5,
+                    "headings": ["Section Title"],
+                    "content_type": "text",
+                },
+            )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["doc_id"] == "doc-test"
+    assert data["filename"] == "test.pdf"
+    assert data["chunk_index"] == 22
+    assert data["chunk_id"] == chunk_id
+    assert data["created"] is True
+    assert data["message"] == "Chunk injected successfully"
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_inherits_doc_category():
+    """Create chunk inherits doc_category from existing file when not provided."""
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-001",
+            payload={
+                "chunk_index": 0,
+                "filename": "test.pdf",
+                "text": "existing chunk",
+                "doc_category": "handbook",
+                "academic_year": "2023/2024",
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "text": "Injected chunk text",
+                    "chunk_index": 22,
+                },
+            )
+
+    assert response.status_code == 200
+    call_args = mock_upsert.call_args
+    payload = call_args.args[3]
+    assert payload["doc_category"] == "handbook"
+    assert payload["academic_year"] == "2023/2024"
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_enriched_text_with_headings():
+    """Create chunk generates enriched_text with headings prepended."""
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-001",
+            payload={
+                "chunk_index": 0,
+                "filename": "test.pdf",
+                "text": "existing",
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "text": "Chunk content",
+                    "chunk_index": 5,
+                    "headings": ["Rules Section"],
+                },
+            )
+
+    call_kwargs = mock_embed.call_args
+    enriched = call_kwargs.args[0]
+    assert enriched == "[Rules Section]\nChunk content"
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_enriched_text_without_headings():
+    """Create chunk uses raw text as enriched_text when no headings provided."""
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-001",
+            payload={
+                "chunk_index": 0,
+                "filename": "test.pdf",
+                "text": "existing",
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "text": "Chunk content",
+                    "chunk_index": 5,
+                },
+            )
+
+    call_kwargs = mock_embed.call_args
+    enriched = call_kwargs.args[0]
+    assert enriched == "Chunk content"
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_conflict():
+    """Create chunk returns 409 when chunk_index already exists."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 5)
+    fake_points = [
+        _FakePoint(
+            point_id=chunk_id,
+            payload={
+                "chunk_index": 5,
+                "filename": "test.pdf",
+                "text": "existing chunk",
+            },
+        ),
+    ]
+
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll:
+        mock_scroll.return_value = fake_points
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "text": "New chunk text",
+                    "chunk_index": 5,
+                },
+            )
+
+    assert response.status_code == 409
+    data = response.json()
+    assert data["title"] == "Conflict"
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_not_found():
+    """Create chunk returns 404 for unknown doc_id."""
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll:
+        mock_scroll.return_value = []
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "unknown-doc",
+                    "text": "New chunk text",
+                    "chunk_index": 5,
+                },
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_empty_text():
+    """Create chunk returns 422 for empty text."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/ingest/by-file/chunks",
+            json={
+                "doc_id": "doc-test",
+                "text": "",
+                "chunk_index": 5,
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_whitespace_text():
+    """Create chunk returns 422 for whitespace-only text."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/ingest/by-file/chunks",
+            json={
+                "doc_id": "doc-test",
+                "text": "   ",
+                "chunk_index": 5,
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_chunk_negative_index():
+    """Create chunk returns 422 for negative chunk_index."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/ingest/by-file/chunks",
+            json={
+                "doc_id": "doc-test",
+                "text": "Valid text",
+                "chunk_index": -1,
+            },
+        )
+
+    assert response.status_code == 422
+
+
+# ── Chunk Update (Issue 3) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_success():
+    """Update chunk endpoint overwrites text and returns success."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 17)
+    fake_points = [
+        _FakePoint(
+            point_id=chunk_id,
+            payload={
+                "chunk_index": 17,
+                "filename": "test.pdf",
+                "text": "old text",
+                "doc_category": "guide",
+                "academic_year": "2024/2025",
+                "headings": ["Old Heading"],
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = {"point_id": chunk_id, "payload": fake_points[0].payload}
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.patch(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                    "text": "updated text content",
+                    "headings": ["Tata Tertib"],
+                    "page": 1,
+                    "content_type": "text",
+                },
+            )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["doc_id"] == "doc-test"
+    assert data["filename"] == "test.pdf"
+    assert data["chunk_index"] == 17
+    assert data["chunk_id"] == chunk_id
+    assert data["updated"] is True
+    assert data["message"] == "Chunk updated successfully"
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_preserves_unspecified_fields():
+    """Update chunk preserves doc_category and academic_year when not in request."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 17)
+    existing_payload = {
+        "chunk_index": 17,
+        "filename": "test.pdf",
+        "text": "old text",
+        "doc_category": "handbook",
+        "academic_year": "2023/2024",
+        "headings": ["Old Heading"],
+    }
+    fake_points = [
+        _FakePoint(point_id=chunk_id, payload=existing_payload),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = {"point_id": chunk_id, "payload": existing_payload}
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.patch(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                    "text": "new text only",
+                },
+            )
+
+    call_args = mock_upsert.call_args
+    payload = call_args.args[3]
+    assert payload["doc_category"] == "handbook"
+    assert payload["academic_year"] == "2023/2024"
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_enriched_text_regenerated():
+    """Update chunk regenerates enriched_text from new text and headings."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 17)
+    existing_payload = {
+        "chunk_index": 17,
+        "filename": "test.pdf",
+        "text": "old text",
+        "headings": ["Old Heading"],
+    }
+    fake_points = [
+        _FakePoint(point_id=chunk_id, payload=existing_payload),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+        patch("app.api.routers.ingestion.embed_svc.embed_query", new_callable=AsyncMock) as mock_embed,
+        patch("app.api.routers.ingestion.vs._encode_sparse") as mock_sparse,
+        patch("app.api.routers.ingestion.vs.upsert_single_chunk", new_callable=AsyncMock) as mock_upsert,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = {"point_id": chunk_id, "payload": existing_payload}
+        mock_embed.return_value = [0.1, 0.2, 0.3]
+        mock_sparse.return_value = [MagicMock()]
+        mock_upsert.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.patch(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                    "text": "new text",
+                    "headings": ["New Heading"],
+                },
+            )
+
+    call_kwargs = mock_embed.call_args
+    enriched = call_kwargs.args[0]
+    assert enriched == "[New Heading]\nnew text"
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_not_found_doc_id():
+    """Update chunk returns 404 for unknown doc_id."""
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll:
+        mock_scroll.return_value = []
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.patch(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "unknown-doc",
+                    "chunk_index": 17,
+                    "text": "new text",
+                },
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_not_found_index():
+    """Update chunk returns 404 for unknown chunk_index."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-001",
+            payload={
+                "chunk_index": 5,
+                "filename": "test.pdf",
+                "text": "existing",
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.patch(
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 99,
+                    "text": "new text",
+                },
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_empty_text():
+    """Update chunk returns 422 for empty text."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/ingest/by-file/chunks",
+            json={
+                "doc_id": "doc-test",
+                "chunk_index": 17,
+                "text": "",
+            },
+        )
+
+    assert response.status_code == 422
+
+
+# ── Chunk Delete (Issue 4) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_chunk_success():
+    """Delete chunk endpoint removes a chunk and returns success."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 17)
+    existing_payload = {
+        "chunk_index": 17,
+        "filename": "test.pdf",
+        "text": "chunk to delete",
+    }
+    fake_points = [
+        _FakePoint(point_id=chunk_id, payload=existing_payload),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+        patch("app.api.routers.ingestion.vs.delete_single_chunk", new_callable=AsyncMock) as mock_delete,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = {"point_id": chunk_id, "payload": existing_payload}
+        mock_delete.return_value = True
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE",
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                },
+            )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["doc_id"] == "doc-test"
+    assert data["filename"] == "test.pdf"
+    assert data["chunk_index"] == 17
+    assert data["chunk_id"] == chunk_id
+    assert data["deleted"] is True
+    assert data["message"] == "Chunk deleted successfully"
+
+
+@pytest.mark.asyncio
+async def test_delete_chunk_not_found_doc_id():
+    """Delete chunk returns 404 for unknown doc_id."""
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll:
+        mock_scroll.return_value = []
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE",
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "unknown-doc",
+                    "chunk_index": 17,
+                },
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_delete_chunk_not_found_index():
+    """Delete chunk returns 404 for unknown chunk_index."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 5)
+    fake_points = [
+        _FakePoint(
+            point_id=chunk_id,
+            payload={
+                "chunk_index": 5,
+                "filename": "test.pdf",
+                "text": "existing",
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE",
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 99,
+                },
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_delete_chunk_twice_returns_404():
+    """Delete chunk twice returns 404 on second call."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 17)
+    existing_payload = {
+        "chunk_index": 17,
+        "filename": "test.pdf",
+        "text": "chunk to delete",
+    }
+    fake_points = [
+        _FakePoint(point_id=chunk_id, payload=existing_payload),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+        patch("app.api.routers.ingestion.vs.delete_single_chunk", new_callable=AsyncMock) as mock_delete,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = {"point_id": chunk_id, "payload": existing_payload}
+        mock_delete.return_value = True
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE",
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                },
+            )
+
+    assert response.status_code == 200
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = None
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE",
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                },
+            )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_chunk_negative_index():
+    """Delete chunk returns 422 for negative chunk_index."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.request(
+            "DELETE",
+            "/ingest/by-file/chunks",
+            json={
+                "doc_id": "doc-test",
+                "chunk_index": -1,
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_chunk_other_chunks_unchanged():
+    """Delete chunk does not affect other chunks for the same file."""
+    from app.utils.helpers import generate_chunk_point_id
+
+    chunk_id = generate_chunk_point_id("doc-test", 17)
+    existing_payload = {
+        "chunk_index": 17,
+        "filename": "test.pdf",
+        "text": "chunk to delete",
+    }
+    fake_points = [
+        _FakePoint(point_id=chunk_id, payload=existing_payload),
+        _FakePoint(
+            point_id="chunk-other",
+            payload={
+                "chunk_index": 5,
+                "filename": "test.pdf",
+                "text": "other chunk",
+            },
+        ),
+    ]
+
+    with (
+        patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id", new_callable=AsyncMock) as mock_scroll,
+        patch("app.api.routers.ingestion.vs.get_chunk_by_doc_id_and_index", new_callable=AsyncMock) as mock_get,
+        patch("app.api.routers.ingestion.vs.delete_single_chunk", new_callable=AsyncMock) as mock_delete,
+    ):
+        mock_scroll.return_value = fake_points
+        mock_get.return_value = {"point_id": chunk_id, "payload": existing_payload}
+        mock_delete.return_value = True
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "DELETE",
+                "/ingest/by-file/chunks",
+                json={
+                    "doc_id": "doc-test",
+                    "chunk_index": 17,
+                },
+            )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["chunk_index"] == 17

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,6 +137,113 @@ async def test_chat_invalid_message():
 
 
 @pytest.mark.asyncio
+async def test_list_files_empty():
+    """List files endpoint returns 200 with empty list when no files ingested."""
+    with patch("app.api.routers.ingestion.vs.list_files") as mock_list:
+        mock_list.return_value = []
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/ingest/files")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_files"] == 0
+        assert data["files"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_files_two_files():
+    """List files endpoint returns one entry per ingested file."""
+    file_entries = [
+        {
+            "doc_id": "doc-abc123",
+            "filename": "enrollment.pdf",
+            "doc_category": "Academic",
+            "academic_year": "2024/2025",
+            "total_chunks": 5,
+        },
+        {
+            "doc_id": "doc-def456",
+            "filename": "schedule.pdf",
+            "doc_category": "Administrative",
+            "academic_year": "2024/2025",
+            "total_chunks": 3,
+        },
+    ]
+
+    with patch("app.api.routers.ingestion.vs.list_files") as mock_list:
+        mock_list.return_value = file_entries
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/ingest/files")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_files"] == 2
+        # Results sorted by filename ascending
+        assert data["files"][0]["filename"] == "enrollment.pdf"
+        assert data["files"][1]["filename"] == "schedule.pdf"
+        assert data["files"][0]["total_chunks"] == 5
+        assert data["files"][1]["total_chunks"] == 3
+        assert data["files"][0]["doc_category"] == "Academic"
+        assert data["files"][0]["academic_year"] == "2024/2025"
+
+
+@pytest.mark.asyncio
+async def test_list_files_total_chunks_matches():
+    """List files endpoint accurately reflects stored chunk counts."""
+    file_entries = [
+        {
+            "doc_id": "doc-xyz",
+            "filename": "large-doc.pdf",
+            "doc_category": None,
+            "academic_year": None,
+            "total_chunks": 42,
+        },
+    ]
+
+    with patch("app.api.routers.ingestion.vs.list_files") as mock_list:
+        mock_list.return_value = file_entries
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/ingest/files")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["files"][0]["total_chunks"] == 42
+
+
+@pytest.mark.asyncio
+async def test_list_files_idempotent_reingest():
+    """Re-ingesting the same file results in only one entry."""
+    # Simulates deduplication: even if called multiple times, same doc_id
+    file_entries = [
+        {
+            "doc_id": "doc-duplicate",
+            "filename": "re-ingested.pdf",
+            "doc_category": "Academic",
+            "academic_year": "2024/2025",
+            "total_chunks": 10,
+        },
+    ]
+
+    with patch("app.api.routers.ingestion.vs.list_files") as mock_list:
+        mock_list.return_value = file_entries
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/ingest/files")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_files"] == 1
+        assert data["files"][0]["doc_id"] == "doc-duplicate"
+
+
+@pytest.mark.asyncio
 async def test_ingest_unsupported_file():
     """Ingest endpoint rejects unsupported file types with RFC 7807 error."""
     transport = ASGITransport(app=app)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -356,6 +356,268 @@ async def test_delete_no_other_files_affected():
         assert data["deleted_chunks"] == 7
 
 
+# ── Chunks Listing (Issue 1) ────────────────────────────
+
+
+class _FakePoint:
+    """Minimal fake Qdrant point for testing."""
+
+    def __init__(self, point_id, payload):
+        self.id = point_id
+        self.payload = payload
+
+
+@pytest.mark.asyncio
+async def test_list_chunks_success():
+    """List chunks endpoint returns all chunks for a doc_id."""
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-001",
+            payload={
+                "chunk_index": 0,
+                "page": 1,
+                "headings": ["Introduction"],
+                "content_type": "text",
+                "doc_category": "guide",
+                "academic_year": "2024/2025",
+                "text": "This is chunk 1.",
+                "enriched_text": "[Introduction]\nThis is chunk 1.",
+                "filename": "test.pdf",
+            },
+        ),
+        _FakePoint(
+            point_id="chunk-002",
+            payload={
+                "chunk_index": 1,
+                "page": 2,
+                "headings": ["Rules"],
+                "content_type": "text",
+                "doc_category": "guide",
+                "academic_year": "2024/2025",
+                "text": "This is chunk 2.",
+                "enriched_text": "[Rules]\nThis is chunk 2.",
+                "filename": "test.pdf",
+            },
+        ),
+    ]
+
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id") as mock_scroll:
+        mock_scroll.return_value = fake_points
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/ingest/by-file/chunks", params={"doc_id": "doc-test"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["doc_id"] == "doc-test"
+        assert data["filename"] == "test.pdf"
+        assert data["total_chunks"] == 2
+        assert data["chunks"][0]["chunk_id"] == "chunk-001"
+        assert data["chunks"][0]["chunk_index"] == 0
+        assert data["chunks"][0]["page"] == 1
+        assert data["chunks"][0]["headings"] == ["Introduction"]
+        assert data["chunks"][0]["content_type"] == "text"
+        assert data["chunks"][0]["doc_category"] == "guide"
+        assert data["chunks"][0]["academic_year"] == "2024/2025"
+        assert data["chunks"][0]["enriched_text"] is not None
+
+
+@pytest.mark.asyncio
+async def test_list_chunks_sorted_by_chunk_index():
+    """List chunks results are always sorted by chunk_index."""
+    # Return points out of order — endpoint should sort them
+    fake_points = [
+        _FakePoint(
+            point_id="chunk-002",
+            payload={"chunk_index": 5, "filename": "test.pdf", "text": "chunk 5"},
+        ),
+        _FakePoint(
+            point_id="chunk-001",
+            payload={"chunk_index": 2, "filename": "test.pdf", "text": "chunk 2"},
+        ),
+        _FakePoint(
+            point_id="chunk-003",
+            payload={"chunk_index": 1, "filename": "test.pdf", "text": "chunk 1"},
+        ),
+    ]
+
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id") as mock_scroll:
+        mock_scroll.return_value = sorted(
+            fake_points, key=lambda p: p.payload["chunk_index"]
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/ingest/by-file/chunks", params={"doc_id": "doc-test"}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        indices = [c["chunk_index"] for c in data["chunks"]]
+        assert indices == [1, 2, 5]
+
+
+@pytest.mark.asyncio
+async def test_list_chunks_not_found():
+    """List chunks returns 404 for unknown doc_id."""
+    with patch("app.api.routers.ingestion.vs.scroll_chunks_by_doc_id") as mock_scroll:
+        mock_scroll.return_value = []
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/ingest/by-file/chunks", params={"doc_id": "unknown"}
+            )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["title"] == "Not Found"
+
+
+@pytest.mark.asyncio
+async def test_list_chunks_missing_param():
+    """List chunks returns 422 when doc_id param is missing."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/ingest/by-file/chunks")
+
+    assert response.status_code == 422
+
+
+# ── File Rename (Issue 7) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_file_success():
+    """Rename endpoint updates filename and returns chunk count."""
+    rename_result = {
+        "doc_id": "doc-abc123",
+        "filename": "new-name.pdf",
+        "updated_chunks": 5,
+    }
+
+    with (
+        patch("app.api.routers.ingestion.vs.list_files") as mock_list,
+        patch("app.api.routers.ingestion.vs.rename_file") as mock_rename,
+    ):
+        mock_list.return_value = []  # no collision
+        mock_rename.return_value = rename_result
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "PATCH",
+                "/ingest/files",
+                json={"doc_id": "doc-abc123", "filename": "new-name.pdf"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["doc_id"] == "doc-abc123"
+        assert data["filename"] == "new-name.pdf"
+        assert data["updated_chunks"] == 5
+        assert data["updated"] is True
+
+
+@pytest.mark.asyncio
+async def test_rename_file_not_found():
+    """Rename returns 404 for unknown doc_id."""
+    from app.utils.exceptions import VectorStoreError
+
+    with (
+        patch("app.api.routers.ingestion.vs.list_files") as mock_list,
+        patch("app.api.routers.ingestion.vs.rename_file") as mock_rename,
+    ):
+        mock_list.return_value = []
+        mock_rename.side_effect = VectorStoreError(
+            "File with doc_id='unknown' not found"
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "PATCH",
+                "/ingest/files",
+                json={"doc_id": "unknown", "filename": "new.pdf"},
+            )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_rename_file_conflict():
+    """Rename returns 409 when filename already used by another doc_id."""
+    with patch("app.api.routers.ingestion.vs.list_files") as mock_list:
+        mock_list.return_value = [
+            {
+                "doc_id": "other-doc",
+                "filename": "existing.pdf",
+                "total_chunks": 3,
+            }
+        ]
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "PATCH",
+                "/ingest/files",
+                json={"doc_id": "my-doc", "filename": "existing.pdf"},
+            )
+
+    assert response.status_code == 409
+    data = response.json()
+    assert data["title"] == "Conflict"
+
+
+@pytest.mark.asyncio
+async def test_rename_file_empty_filename():
+    """Rename returns 422 when filename is empty."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.request(
+            "PATCH",
+            "/ingest/files",
+            json={"doc_id": "doc-abc", "filename": ""},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rename_no_other_files_affected():
+    """Renaming one file does not affect other files."""
+    rename_result = {
+        "doc_id": "doc-target",
+        "filename": "renamed.pdf",
+        "updated_chunks": 7,
+    }
+
+    with (
+        patch("app.api.routers.ingestion.vs.list_files") as mock_list,
+        patch("app.api.routers.ingestion.vs.rename_file") as mock_rename,
+    ):
+        mock_list.return_value = []
+        mock_rename.return_value = rename_result
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.request(
+                "PATCH",
+                "/ingest/files",
+                json={"doc_id": "doc-target", "filename": "renamed.pdf"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # doc_id unchanged
+        assert data["doc_id"] == "doc-target"
+        assert data["filename"] == "renamed.pdf"
+
+
 @pytest.mark.asyncio
 async def test_ingest_unsupported_file():
     """Ingest endpoint rejects unsupported file types with RFC 7807 error."""


### PR DESCRIPTION
## Summary

- Add **POST /ingest/by-file/chunks** — inject a manually written chunk into an existing file's chunk inventory in Qdrant
- Add **PATCH /ingest/by-file/chunks** — overwrite the text and optionally metadata of one specific chunk
- Add **DELETE /ingest/by-file/chunks** — remove a single chunk without affecting the rest of the file's chunks

## Key Features

### Create (Issue 2)
- Deterministic chunk ID via generate_chunk_point_id(doc_id, chunk_index)
- Automatic nriched_text generation from 	ext and headings
- Inherits doc_category and cademic_year from existing file when omitted
- Returns 409 Conflict if doc_id + chunk_index already exists

### Update (Issue 3)
- Merges only provided fields; unspecified optional fields are preserved
- Regenerates nriched_text, dense vector, and sparse vector
- Uses same deterministic chunk_id — identity never changes

### Delete (Issue 4)
- Deletes only the targeted point by chunk_id
- Does not renumber or re-index remaining chunks
- Returns 404 on second delete attempt

## Error Handling

| Condition | Response |
|---|---|
| doc_id not found | 404 Not Found |
| chunk_index not found | 404 Not Found |
| chunk_index already exists (POST) | 409 Conflict |
| 	ext empty/whitespace | 422 Validation Error |
| chunk_index negative | 422 Validation Error |

## Tests

- 21 new test cases covering all success and error paths
- All 44 API tests passing

## Files Changed

- pp/api/models.py — Pydantic models for chunk CRUD requests/responses
- pp/api/routers/ingestion.py — Three new endpoint handlers
- pp/services/vectorstore.py — Single-chunk upsert, get, and delete helpers
- 	ests/test_api.py — Comprehensive test coverage
